### PR TITLE
Spectator-Teleport Implementation

### DIFF
--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -1340,12 +1340,21 @@ namespace MinecraftClient
         }
 
         /// <summary>
-        /// Teleport to player/entity in spectator mode
+        /// Teleport to player in spectator mode
         /// </summary>
-        /// <param name="entity">entity to teleport to</param>
+        /// <param name="entity">player to teleport to</param>
         protected bool SpectatorTeleport(Entity entity)
         {
             return Handler.Spectate(entity);
+        }
+
+        /// <summary>
+        /// Teleport to player/entity in spectator mode
+        /// </summary>
+        /// <param name="uuid">uuid of entity to teleport to</param>
+        protected bool SpectatorTeleport(Guid UUID)
+        {
+            return Handler.SpectateByUUID(UUID);
         }
         
         /// <summary>

--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -1338,6 +1338,15 @@ namespace MinecraftClient
         {
             return Handler.SelectTrade(selectedSlot);
         }
+
+        /// <summary>
+        /// Teleport to player/entity in spectator mode
+        /// </summary>
+        /// <param name="entity">entity to teleport to</param>
+        protected bool SpectatorTeleport(Entity entity)
+        {
+            return Handler.Spectate(entity);
+        }
         
         /// <summary>
         /// Update command block

--- a/MinecraftClient/ChatBots/ScriptScheduler.cs
+++ b/MinecraftClient/ChatBots/ScriptScheduler.cs
@@ -9,7 +9,7 @@ namespace MinecraftClient.ChatBots
     /// <summary>
     /// Trigger scripts on specific events
     /// </summary>
-    
+
     public class ScriptScheduler : ChatBot
     {
         private class TaskDesc

--- a/MinecraftClient/ChatBots/ScriptScheduler.cs
+++ b/MinecraftClient/ChatBots/ScriptScheduler.cs
@@ -9,6 +9,7 @@ namespace MinecraftClient.ChatBots
     /// <summary>
     /// Trigger scripts on specific events
     /// </summary>
+    
     public class ScriptScheduler : ChatBot
     {
         private class TaskDesc

--- a/MinecraftClient/ChatBots/ScriptScheduler.cs
+++ b/MinecraftClient/ChatBots/ScriptScheduler.cs
@@ -9,7 +9,6 @@ namespace MinecraftClient.ChatBots
     /// <summary>
     /// Trigger scripts on specific events
     /// </summary>
-
     public class ScriptScheduler : ChatBot
     {
         private class TaskDesc

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -1695,6 +1695,22 @@ namespace MinecraftClient
         {
             return InvokeOnMainThread(() => handler.UpdateCommandBlock(location, command, mode, flags));
         }
+
+        /// <summary>
+        /// Teleport to player/entity in spectator mode
+        /// </summary>
+        /// <param name="entity">entity to teleport to</param>
+        public bool Spectate(Entity entity)
+        {
+            if(GetGamemode() == 3)
+            {
+                return InvokeOnMainThread(() => handler.SendSpectate(entity.UUID));
+            }
+            else
+            {
+                return false;
+            }
+        }
         #endregion
 
         #region Event handlers: An event occurs on the Server

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -1697,14 +1697,33 @@ namespace MinecraftClient
         }
 
         /// <summary>
+        /// Teleport to player in spectator mode
+        /// </summary>
+        /// <param name="entity">Player to teleport to</param>
+        /// Teleporting to other entityies is NOT implemented yet
+        public bool Spectate(Entity entity)
+        {
+            if(entity.Type == EntityType.Player)
+            {
+                return SpectateByUUID(entity.UUID);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Teleport to player/entity in spectator mode
         /// </summary>
-        /// <param name="entity">entity to teleport to</param>
-        public bool Spectate(Entity entity)
+        /// <param name="UUID">UUID of player/entity to teleport to</param>
+        public bool SpectateByUUID(Guid UUID)
         {
             if(GetGamemode() == 3)
             {
-                return InvokeOnMainThread(() => handler.SendSpectate(entity.UUID));
+                if(InvokeRequired)
+                    return InvokeOnMainThread(() => SpectateByUUID(UUID));
+                return handler.SendSpectate(UUID);
             }
             else
             {

--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -1048,6 +1048,16 @@ namespace MinecraftClient.Protocol.Handlers
         }
 
         /// <summary>
+        /// Get a byte array from the given uuid
+        /// </summary>
+        /// <param name="uuid">UUID of Player/Entity</param>
+        /// <returns>UUID representation</returns>
+        public byte[] GetUUID(Guid UUID)
+        {
+            return UUID.ToBigEndianBytes();
+        }
+
+        /// <summary>
         /// Easily append several byte arrays
         /// </summary>
         /// <param name="bytes">Bytes to append</param>

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -860,5 +860,10 @@ namespace MinecraftClient.Protocol.Handlers
         {
             return false; //MC 1.13+
         }
+
+        public bool SendSpectate(Guid UUID)
+        {
+            return false; //Currently not implemented
+        }
     }
 }

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -2057,5 +2057,19 @@ namespace MinecraftClient.Protocol.Handlers
             }
             else { return false; }
         }
+
+        public bool SendSpectate(Guid UUID)
+        {
+            try
+            {
+                List<byte> packet = new List<byte>();
+                packet.AddRange(dataTypes.GetUUID(UUID));
+                SendPacket(PacketTypesOut.Spectate, packet);
+                return true;
+            }
+            catch (SocketException) { return false; }
+            catch (System.IO.IOException) { return false; }
+            catch (ObjectDisposedException) { return false; }
+        }
     }
 }

--- a/MinecraftClient/Protocol/IMinecraftCom.cs
+++ b/MinecraftClient/Protocol/IMinecraftCom.cs
@@ -237,6 +237,12 @@ namespace MinecraftClient.Protocol
         bool SelectTrade(int selectedSlot);
 
         /// <summary>
+        /// Spectate a player/entity
+        /// </summary>
+        /// <param name="uuid">The uuid of the player/entity to spectate/teleport to.</param>
+        bool SendSpectate(Guid uuid);
+
+        /// <summary>
         /// Get net read thread (main thread) ID
         /// </summary>
         /// <returns>Net read thread ID</returns>


### PR DESCRIPTION
I just implemented what I requested in an Issue. Hope I did it right, because this is my first pull request. Feel free to change anything or tell me what should be different, if there is any kind of Enhancement or Problem to take care of. Basically this change allows MCC-Users to use `SpectatorTeleport(Player from GetEntities())` and `SpectatorTeleport(new Guid(String of Player or Entity-UUID))` int their Chatbots.