### PR TITLE
Add setrnd command

### DIFF
--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -30,7 +30,7 @@ namespace MinecraftClient.Commands
                         }
                         catch (Exception)
                         {
-                            return Translations.Get("cmd.setrnd.format");
+                            return Translations.Get("cmd.setrndnum.format");
                         }
 
                         if (num2 < num1)
@@ -44,18 +44,18 @@ namespace MinecraftClient.Commands
                         {
                             return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
                         }
-                        else return Translations.Get("cmd.setrnd.format");
+                        else return Translations.Get("cmd.setrndnum.format");
                     }
                     else
                     {
                         string argString = command.Substring(command.IndexOf(args[0]) + args[0].Length, command.Length - 8 - args[0].Length);
                         List<string> values = parseCommandLine(argString);
 
-                        if (Settings.SetVar(args[0], values[rand.Next(0, values.Count)]))
+                        if (values.Count > 0 && Settings.SetVar(args[0], values[rand.Next(0, values.Count)]))
                         {
                             return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
                         }
-                        else return Translations.Get("cmd.setrnd.format");
+                        else return Translations.Get("cmd.setrndstr.format");
                     }
                 }
                 else return GetCmdDescTranslated();

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -20,16 +20,21 @@ namespace MinecraftClient.Commands
 
                 if (args[0] == "player")
                 {
+                    // remember to use no further arguments
                     if (args.Length > 1)
                         return Translations.Get("cmd.setrndplayer.format");
 
-                    var test = handler.GetUsername();
+                    // get all playernames without the bot itself
                     string[] playernames = handler.GetOnlinePlayers().Where(name => name != handler.GetUsername()).ToArray();
+
+                    // if there are players apart from the bot online
                     if (playernames.Length > 0)
                     {
+                        // get a random one and assign it
                         Settings.SetVar("player", playernames[rand.Next(0, playernames.Length)]);
                         return string.Format("Set %{0}% to {1}.", "player", Settings.GetVar("player"));
                     }
+                    // you are the only one on the server
                     else { return Translations.Get("cmd.setrndplayer.lonely"); }
                 }
                 else if (args.Length > 1)

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -8,7 +8,7 @@ namespace MinecraftClient.Commands
         public override string CmdName { get { return "setrnd"; } }
         public override string CmdUsage { get { return "setrnd varname -7to10 OR string1,string2,string3"; } }
         public override string CmdDesc { get { return "cmd.set.desc"; } }
-        public static Random rand = new Random();
+        private static Random rand = new Random();
 
         public override string Run(McClient handler, string command, Dictionary<string, object> localVars)
         {

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 
@@ -16,7 +17,22 @@ namespace MinecraftClient.Commands
             if (hasArg(command))
             {
                 string[] args = getArg(command).Split(' ');
-                if (args.Length > 1)
+
+                if (args[0] == "player")
+                {
+                    if (args.Length > 1)
+                        return Translations.Get("cmd.setrndplayer.format");
+
+                    var test = handler.GetUsername();
+                    string[] playernames = handler.GetOnlinePlayers().Where(name => name != handler.GetUsername()).ToArray();
+                    if (playernames.Length > 0)
+                    {
+                        Settings.SetVar("player", playernames[rand.Next(0, playernames.Length)]);
+                        return string.Format("Set %{0}% to {1}.", "player", Settings.GetVar("player"));
+                    }
+                    else { return Translations.Get("cmd.setrndplayer.lonely"); }
+                }
+                else if (args.Length > 1)
                 {
                     // detect "to" keyword in string
                     if (args.Length == 2 && args[1].Contains("to"))

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Text;
 
 namespace MinecraftClient.Commands
@@ -50,9 +48,7 @@ namespace MinecraftClient.Commands
                     }
                     else
                     {
-                        var test = command.IndexOf(args[0]) + args[0].Length;
-                        var test1 = command.Length - 8 - args[0].Length;
-                        string argString = command.Substring(test, test1);
+                        string argString = command.Substring(command.IndexOf(args[0]) + args[0].Length, command.Length - 8 - args[0].Length);
                         List<string> values = parseCommandLine(argString);
 
                         if (Settings.SetVar(args[0], values[rand.Next(0, values.Count)]))

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -18,27 +18,8 @@ namespace MinecraftClient.Commands
             {
                 string[] args = getArg(command).Split(' ');
 
-                if (args[0] == "player")
-                {
-                    // remember to use no further arguments
-                    if (args.Length > 1)
-                        return Translations.Get("cmd.setrndplayer.format");
-
-                    // get all playernames without the bot itself
-                    string[] playernames = handler.GetOnlinePlayers().Where(name => name != handler.GetUsername()).ToArray();
-
-                    // if there are players apart from the bot online
-                    if (playernames.Length > 0)
-                    {
-                        // get a random one and assign it
-                        Settings.SetVar("player", playernames[rand.Next(0, playernames.Length)]);
-                        return string.Format("Set %{0}% to {1}.", "player", Settings.GetVar("player"));
-                    }
-                    // you are the only one on the server
-                    else { return Translations.Get("cmd.setrndplayer.lonely"); }
-                }
-                else if (args.Length > 1)
-                {
+               if (args.Length > 1)
+               {
                     // detect "to" keyword in string
                     if (args.Length == 2 && args[1].Contains("to"))
                     {

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -7,8 +7,8 @@ namespace MinecraftClient.Commands
     class SetRnd : Command
     {
         public override string CmdName { get { return "setrnd"; } }
-        public override string CmdUsage { get { return "setrnd varname -7to10 OR string1,string2,string3"; } }
-        public override string CmdDesc { get { return "cmd.set.desc"; } }
+        public override string CmdUsage { get { return Translations.Get("cmd.setrnd.format"); } }
+        public override string CmdDesc { get { return "cmd.setrnd.desc"; } }
         private static readonly Random rand = new Random();
 
         public override string Run(McClient handler, string command, Dictionary<string, object> localVars)
@@ -30,7 +30,7 @@ namespace MinecraftClient.Commands
                         }
                         catch (Exception)
                         {
-                            return "Unknown syntax";
+                            return Translations.Get("cmd.setrnd.format");
                         }
 
                         if (num2 < num1)
@@ -44,7 +44,7 @@ namespace MinecraftClient.Commands
                         {
                             return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
                         }
-                        else return Translations.Get("cmd.set.format");
+                        else return Translations.Get("cmd.setrnd.format");
                     }
                     else
                     {
@@ -55,7 +55,7 @@ namespace MinecraftClient.Commands
                         {
                             return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
                         }
-                        else return Translations.Get("cmd.set.format");
+                        else return Translations.Get("cmd.setrnd.format");
                     }
                 }
                 else return GetCmdDescTranslated();

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MinecraftClient.Commands
+{
+    class SetRnd : Command
+    {
+        public override string CmdName { get { return "setrnd"; } }
+        public override string CmdUsage { get { return "setrnd varname -7to10 OR string1,string2,string3"; } }
+        public override string CmdDesc { get { return "cmd.set.desc"; } }
+        public static Random rand = new Random();
+
+        public override string Run(McClient handler, string command, Dictionary<string, object> localVars)
+        {
+            if (hasArg(command))
+            {
+                string[] args = getArg(command).Split(' ');
+                if (args.Length > 1)
+                {
+                    if (args[1].Contains("to"))
+                    {
+                        int num1;
+                        int num2;
+
+                        try
+                        {
+                            num1 = Convert.ToInt32(args[1].Substring(0, args[1].IndexOf('t')));
+                            num2 = Convert.ToInt32(args[1].Substring(args[1].IndexOf('o') + 1, args[1].Length - 1 - args[1].IndexOf('o')));
+                        }
+                        catch (Exception)
+                        {
+                            return "Unknown syntax";
+                        }
+
+                        if (num2 < num1)
+                        {
+                            int temp = num1;
+                            num1 = num2;
+                            num2 = temp;
+                        }
+
+                        if (Settings.SetVar(args[0], rand.Next(num1, num2)))
+                        {
+                            return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
+                        }
+                        else return Translations.Get("cmd.set.format");
+                    }
+                    else if (args[1].Contains(","))
+                    {
+                        string[] values = args[1].Split(',');
+
+                        if (Settings.SetVar(args[0], values[rand.Next(0, values.Length)]))
+                        {
+                            return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
+                        }
+                        else return Translations.Get("cmd.set.format");
+                    }
+                    else 
+                    {
+                        return "Unknown syntax";
+                    }
+                }
+                else return GetCmdDescTranslated();
+            }
+            else return GetCmdDescTranslated();
+        }
+    }
+}

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -18,11 +18,13 @@ namespace MinecraftClient.Commands
                 string[] args = getArg(command).Split(' ');
                 if (args.Length > 1)
                 {
+                    // detect "to" keyword in string
                     if (args.Length == 2 && args[1].Contains("to"))
                     {
                         int num1;
                         int num2;
 
+                        // try to extract the two numbers from the string
                         try
                         {
                             num1 = Convert.ToInt32(args[1].Substring(0, args[1].IndexOf('t')));
@@ -33,6 +35,7 @@ namespace MinecraftClient.Commands
                             return Translations.Get("cmd.setrndnum.format");
                         }
 
+                        // switch the values if they were entered in the wrong way
                         if (num2 < num1)
                         {
                             int temp = num1;
@@ -40,6 +43,7 @@ namespace MinecraftClient.Commands
                             num2 = temp;
                         }
 
+                        // create a variable or set it to num1 <= varlue < num2
                         if (Settings.SetVar(args[0], rand.Next(num1, num2)))
                         {
                             return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
@@ -48,9 +52,13 @@ namespace MinecraftClient.Commands
                     }
                     else
                     {
+                        // extract all arguments of the command
                         string argString = command.Substring(command.IndexOf(args[0]) + args[0].Length, command.Length - 8 - args[0].Length);
+
+                        // process all arguments similar to regulaer terminals with quotes and escaping
                         List<string> values = parseCommandLine(argString);
 
+                        // create a variable or set it to one of the values
                         if (values.Count > 0 && Settings.SetVar(args[0], values[rand.Next(0, values.Count)]))
                         {
                             return string.Format("Set %{0}% to {1}.", args[0], Settings.GetVar(args[0])); //Success
@@ -63,6 +71,12 @@ namespace MinecraftClient.Commands
             else return GetCmdDescTranslated();
         }
 
+        /// <summary>
+        /// Extract arguments from a given string. Allows quotines and escaping them. 
+        /// Similar to command line arguments in regular terminals.
+        /// </summary>
+        /// <param name="cmdLine">Provided arguments as a string</param>
+        /// <returns>All extracted arguments in a string list</returns>
         private static List<string> parseCommandLine(string cmdLine)
         {
             var args = new List<string>();

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -75,6 +75,7 @@
     <Compile Include="AutoTimeout.cs" />
     <Compile Include="ChatBots\AutoDrop.cs" />
     <Compile Include="ChatBots\Mailer.cs" />
+    <Compile Include="Commands\SetRnd.cs" />
     <Compile Include="Protocol\JwtPayloadDecode.cs" />
     <Compile Include="Protocol\Handlers\PacketPalettes\PacketPalette118.cs" />
     <Compile Include="Protocol\MojangAPI.cs" />

--- a/MinecraftClient/Resources/lang/de.ini
+++ b/MinecraftClient/Resources/lang/de.ini
@@ -332,6 +332,8 @@ cmd.set.format=Variable muss aus A-Za-z0-9 bestehen.
 cmd.setrnd.desc=Setze eine benutzerdefinierte %variable% zufällig auf einen der angegebenen Werte.
 cmd.setrndnum.format=setrnd variable -7to17
 cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
+cmd.setrndplayer.format=Die %player% variable ist eine Konstante, welche immer auf einen zufälligen Spieler gesetzt wird. Hier sind keine Argumente erlaubt.
+cmd.setrndplayer.lonely=Fehlgeschlagen: Der Bot ist der einzige Spieler auf dem Server.
 
 # Sneak
 cmd.sneak.desc=Schaltet Ducken AN/AUS

--- a/MinecraftClient/Resources/lang/de.ini
+++ b/MinecraftClient/Resources/lang/de.ini
@@ -332,7 +332,6 @@ cmd.set.format=Variable muss aus A-Za-z0-9 bestehen.
 cmd.setrnd.desc=Setze eine benutzerdefinierte %variable% zufällig auf einen der angegebenen Werte.
 cmd.setrndnum.format=setrnd variable -7to17
 cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
-cmd.setrndplayer.format=Die %player% variable ist eine Konstante, welche immer auf einen zufälligen Spieler gesetzt wird. Hier sind keine Argumente erlaubt.
 
 # Sneak
 cmd.sneak.desc=Schaltet Ducken AN/AUS

--- a/MinecraftClient/Resources/lang/de.ini
+++ b/MinecraftClient/Resources/lang/de.ini
@@ -330,7 +330,8 @@ cmd.set.format=Variable muss aus A-Za-z0-9 bestehen.
 
 # SetRnd
 cmd.setrnd.desc=Setze eine benutzerdefinierte %variable% zufällig auf einen der angegebenen Werte.
-cmd.setrnd.format=/setrnd variable string1 "\"string2\" string3" ODER /setrnd variable -7to17
+cmd.setrndnum.format=setrnd variable -7to17
+cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
 
 # Sneak
 cmd.sneak.desc=Schaltet Ducken AN/AUS

--- a/MinecraftClient/Resources/lang/de.ini
+++ b/MinecraftClient/Resources/lang/de.ini
@@ -328,6 +328,10 @@ cmd.send.desc=Sende eine Chatnachricht oder einen Command an den Server.
 cmd.set.desc=Setze eine benutzerdefinierte %variable%.
 cmd.set.format=Variable muss aus A-Za-z0-9 bestehen.
 
+# SetRnd
+cmd.setrnd.desc=Setze eine benutzerdefinierte %variable% zufällig auf einen der angegebenen Werte.
+cmd.setrnd.format=/setrnd variable string1 "\"string2\" string3" ODER /setrnd variable -7to17
+
 # Sneak
 cmd.sneak.desc=Schaltet Ducken AN/AUS
 cmd.sneak.on=Du duckst dich jetzt.

--- a/MinecraftClient/Resources/lang/de.ini
+++ b/MinecraftClient/Resources/lang/de.ini
@@ -333,7 +333,6 @@ cmd.setrnd.desc=Setze eine benutzerdefinierte %variable% zufällig auf einen der
 cmd.setrndnum.format=setrnd variable -7to17
 cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
 cmd.setrndplayer.format=Die %player% variable ist eine Konstante, welche immer auf einen zufälligen Spieler gesetzt wird. Hier sind keine Argumente erlaubt.
-cmd.setrndplayer.lonely=Fehlgeschlagen: Der Bot ist der einzige Spieler auf dem Server.
 
 # Sneak
 cmd.sneak.desc=Schaltet Ducken AN/AUS

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -332,6 +332,8 @@ cmd.set.format=variable name must be A-Za-z0-9.
 cmd.setrnd.desc=set a custom %variable% randomly to a given value.
 cmd.setrndnum.format=setrnd variable -7to17
 cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
+cmd.setrndplayer.format=The %player% variable always is always assigned a random online player. You can not use arguments here.
+cmd.setrndplayer.lonely=Failed: The bot is the only player on the server.
 
 # Sneak
 cmd.sneak.desc=Toggles sneaking

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -330,7 +330,8 @@ cmd.set.format=variable name must be A-Za-z0-9.
 
 # SetRnd
 cmd.setrnd.desc=set a custom %variable% randomly to a given value.
-cmd.setrnd.format=setrnd variable string1 "\"string2\" string3" OR /setrnd variable -7to17
+cmd.setrndnum.format=setrnd variable -7to17
+cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
 
 # Sneak
 cmd.sneak.desc=Toggles sneaking

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -332,7 +332,6 @@ cmd.set.format=variable name must be A-Za-z0-9.
 cmd.setrnd.desc=set a custom %variable% randomly to a given value.
 cmd.setrndnum.format=setrnd variable -7to17
 cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
-cmd.setrndplayer.format=The %player% variable is always assigned a random online player. You can not use arguments here.
 
 # Sneak
 cmd.sneak.desc=Toggles sneaking

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -328,6 +328,10 @@ cmd.send.desc=send a chat message or command.
 cmd.set.desc=set a custom %variable%.
 cmd.set.format=variable name must be A-Za-z0-9.
 
+# SetRnd
+cmd.setrnd.desc=set a custom %variable% randomly to a given value.
+cmd.setrnd.format=setrnd variable string1 "\"string2\" string3" OR /setrnd variable -7to17
+
 # Sneak
 cmd.sneak.desc=Toggles sneaking
 cmd.sneak.on=You are sneaking now

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -332,7 +332,7 @@ cmd.set.format=variable name must be A-Za-z0-9.
 cmd.setrnd.desc=set a custom %variable% randomly to a given value.
 cmd.setrndnum.format=setrnd variable -7to17
 cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
-cmd.setrndplayer.format=The %player% variable always is always assigned a random online player. You can not use arguments here.
+cmd.setrndplayer.format=The %player% variable is always assigned a random online player. You can not use arguments here.
 cmd.setrndplayer.lonely=Failed: The bot is the only player on the server.
 
 # Sneak

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -333,7 +333,6 @@ cmd.setrnd.desc=set a custom %variable% randomly to a given value.
 cmd.setrndnum.format=setrnd variable -7to17
 cmd.setrndstr.format=setrnd variable string1 "\"string2\" string3"
 cmd.setrndplayer.format=The %player% variable is always assigned a random online player. You can not use arguments here.
-cmd.setrndplayer.lonely=Failed: The bot is the only player on the server.
 
 # Sneak
 cmd.sneak.desc=Toggles sneaking

--- a/MinecraftClient/config/README.md
+++ b/MinecraftClient/config/README.md
@@ -122,7 +122,6 @@ In scripts and remote control, no slash is needed to perform the command, eg. `q
  - `set varname=value`: set a value which can be used as `%varname%` in further commands
  - `setrnd variable string1 "\"string2\" string3"`: set a `%variable%` to one of the provided values
  - `setrnd variable -7to10`: set a `%variable%` to a number from -7 to 9
- - `setrnd player`: `%player%` is a constant and always assinged a random playername excluding the bot itself
  - `wait <time>`: wait X ticks (10 ticks = ~1 second. Only for scripts)
  - `move`: used for moving when terrain and movements feature is enabled
  - `look`: used for looking at direction when terrain and movements is enabled

--- a/MinecraftClient/config/README.md
+++ b/MinecraftClient/config/README.md
@@ -120,6 +120,8 @@ In scripts and remote control, no slash is needed to perform the command, eg. `q
  - `log <text>`: display some text in the console (useful for scripts)
  - `list`: list players logged in to the server (uses tab list info sent by server)
  - `set varname=value`: set a value which can be used as `%varname%` in further commands
+ - `setrnd variable string1 "\"string2\" string3"`: set a `%variable%` to one of the provided values
+ - `setrnd variable -7to10`: set a `%variable%` to a number from -7 to 9
  - `wait <time>`: wait X ticks (10 ticks = ~1 second. Only for scripts)
  - `move`: used for moving when terrain and movements feature is enabled
  - `look`: used for looking at direction when terrain and movements is enabled

--- a/MinecraftClient/config/README.md
+++ b/MinecraftClient/config/README.md
@@ -122,6 +122,7 @@ In scripts and remote control, no slash is needed to perform the command, eg. `q
  - `set varname=value`: set a value which can be used as `%varname%` in further commands
  - `setrnd variable string1 "\"string2\" string3"`: set a `%variable%` to one of the provided values
  - `setrnd variable -7to10`: set a `%variable%` to a number from -7 to 9
+ - `setrnd player`: `%player%` is a constant and always assinged a random playername excluding the bot itself
  - `wait <time>`: wait X ticks (10 ticks = ~1 second. Only for scripts)
  - `move`: used for moving when terrain and movements feature is enabled
  - `look`: used for looking at direction when terrain and movements is enabled


### PR DESCRIPTION
Hello there! As #1830 requested a random delay feature for the script scheduler, I had an idea how to implement it.
Therefore I added the "setrnd" command. As the name suggests it is pretty similar to the already existing "set" command.
The only difference is the syntax, you use it as the following:

| Command | Effect |
|---|---|
|`setrnd varname -10to10` | This sets the variable to a value between -10 and 10.|
|`setrnd varname string1,string2,string3,string4...` | This sets the variable value to one of the strings. <br> You can use as many comma seperated strings as you want.|

Due to the fact, that we are using local variables here, it can be used in all kinds of scripts. An example:
```
send Hello server.
setrnd waittime 50to100
wait %waittime%
send Waited: %waittime%
setrnd name ORelio,ReinforceZwei,Daenges
send Hello %name%, how are you?
```