### PR TITLE
Fix respawn packet

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -355,7 +355,10 @@ namespace MinecraftClient.Protocol.Handlers
                         if (protocolversion >= MC116Version)
                         {
                             // TODO handle dimensions for 1.16+, needed for terrain handling
-                            dataTypes.ReadNextString(packetData);
+                            if (protocolversion >= MC1162Version)
+                                dataTypes.ReadNextNbt(packetData);
+                            else
+                                dataTypes.ReadNextString(packetData);
                             this.currentDimension = 0;
                         }
                         else


### PR DESCRIPTION
The Dimension field of `Respawn` packet have changed from Identifier to NBT Tag Compound in 1.16.2 and I forgot to update the packet at that time in PR #1214

Document for [1.16.1](https://wiki.vg/index.php?title=Pre-release_protocol&oldid=15895#Respawn) and [1.16.2](https://wiki.vg/index.php?title=Pre-release_protocol&oldid=16001#Respawn)

I am just wondering why the program didn't crash for like almost 2 years with the mistake there.