### PR TITLE
Fix /move crash and /setrnd

### DIFF
--- a/MinecraftClient/Commands/Move.cs
+++ b/MinecraftClient/Commands/Move.cs
@@ -16,6 +16,9 @@ namespace MinecraftClient.Commands
             List<string> args = getArgs(command.ToLower()).ToList();
             bool takeRisk = false;
 
+            if (args.Count < 1)
+                return GetCmdDescTranslated();
+
             if (args.Contains("-f"))
             {
                 takeRisk = true;

--- a/MinecraftClient/Commands/SetRnd.cs
+++ b/MinecraftClient/Commands/SetRnd.cs
@@ -55,7 +55,7 @@ namespace MinecraftClient.Commands
                     else
                     {
                         // extract all arguments of the command
-                        string argString = command.Substring(command.IndexOf(args[0]) + args[0].Length, command.Length - 8 - args[0].Length);
+                        string argString = command.Substring(8 + command.Split(' ')[1].Length);
 
                         // process all arguments similar to regular terminals with quotes and escaping
                         List<string> values = parseCommandLine(argString);


### PR DESCRIPTION
If you enter only `/move` the client crashes, since there is no first element [here](https://github.com/MCCTeam/Minecraft-Console-Client/blob/master/MinecraftClient/Commands/Move.cs#L25).