### PR TITLE
Read EntityEffect from int instead of byte

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -938,9 +938,10 @@ namespace MinecraftClient.Protocol.Handlers
                         if (handler.GetEntityHandlingEnabled())
                         {
                             int entityid = dataTypes.ReadNextVarInt(packetData);
-                            Inventory.Effects effect = Effects.Speed;
-                            if (Enum.TryParse(dataTypes.ReadNextByte(packetData).ToString(), out effect))
+                            int effectid = dataTypes.ReadNextVarInt(packetData);
+                            if (Enum.IsDefined(typeof(Effects), effectid))
                             {
+                                Effects effect = (Effects)effectid;
                                 int amplifier = dataTypes.ReadNextByte(packetData);
                                 int duration = dataTypes.ReadNextVarInt(packetData);
                                 byte flags = dataTypes.ReadNextByte(packetData);

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -938,14 +938,27 @@ namespace MinecraftClient.Protocol.Handlers
                         if (handler.GetEntityHandlingEnabled())
                         {
                             int entityid = dataTypes.ReadNextVarInt(packetData);
-                            int effectid = dataTypes.ReadNextVarInt(packetData);
-                            if (Enum.IsDefined(typeof(Effects), effectid))
+                            if (protocolversion < MC1182Version)
                             {
-                                Effects effect = (Effects)effectid;
-                                int amplifier = dataTypes.ReadNextByte(packetData);
-                                int duration = dataTypes.ReadNextVarInt(packetData);
-                                byte flags = dataTypes.ReadNextByte(packetData);
-                                handler.OnEntityEffect(entityid, effect, amplifier, duration, flags);
+                                Effects effect = Effects.Speed;
+                                if (Enum.TryParse(dataTypes.ReadNextByte(packetData).ToString(), out effect))
+                                {
+                                    int amplifier = dataTypes.ReadNextByte(packetData);
+                                    int duration = dataTypes.ReadNextVarInt(packetData);
+                                    byte flags = dataTypes.ReadNextByte(packetData);
+                                    handler.OnEntityEffect(entityid, effect, amplifier, duration, flags);
+                                }
+                            } else
+                            {
+                                int effectid = dataTypes.ReadNextVarInt(packetData);
+                                if (Enum.IsDefined(typeof(Effects), effectid))
+                                {
+                                    Effects effect = (Effects)effectid;
+                                    int amplifier = dataTypes.ReadNextByte(packetData);
+                                    int duration = dataTypes.ReadNextVarInt(packetData);
+                                    byte flags = dataTypes.ReadNextByte(packetData);
+                                    handler.OnEntityEffect(entityid, effect, amplifier, duration, flags);
+                                }
                             }
                         }
                         break;


### PR DESCRIPTION
In the 1.18.2 protocol, the effect id is no longer sent as byte, but as integer. For more information, see https://pokechu22.github.io/Burger/diff_1.18.1_1.18.2.html#packets:play_clientbound_65 (Thanks to @Pokechu22)

Entity handling is currently not handled for the new version, so these changes are advance only. 