### PR TITLE
Settings: Make Microsoft as default account type

### DIFF
--- a/MinecraftClient/Resources/config/MinecraftClient.ini
+++ b/MinecraftClient/Resources/config/MinecraftClient.ini
@@ -13,7 +13,7 @@
 login=
 password=
 serverip=
-type=mojang                        # Account type. mojang or microsoft. Also affects interactive login in console.
+type=microsoft                     # Account type. mojang or microsoft. Also affects interactive login in console.
 method=mcc                         # Microsoft Account sign-in method. mcc OR browser
 
 # Advanced settings


### PR DESCRIPTION
Since Mojang have started migration, changing default account type to Microsoft.