### PR TITLE
Square minOffset and maxOffset to match DistanceSquared

### DIFF
--- a/MinecraftClient/Mapping/Movement.cs
+++ b/MinecraftClient/Mapping/Movement.cs
@@ -194,7 +194,7 @@ namespace MinecraftClient.Mapping
                     closestGoal = ClosedSet.OrderBy(checkedLocation => checkedLocation.DistanceSquared(goal)).First();
 
                 // Stop when goal is reached or we are close enough
-                if (current == goal || (minOffset > 0 && current.DistanceSquared(goal) <= minOffset))
+                if (current == goal || (minOffset > 0 && current.DistanceSquared(goal) <= Math.Pow(minOffset, 2)))
                     return ReconstructPath(Came_From, current);
                 else if (ct.IsCancellationRequested)
                     break;              // Return if we are cancelled
@@ -222,7 +222,7 @@ namespace MinecraftClient.Mapping
             }
 
             // Goal could not be reached. Set the path to the closest location if close enough
-            if (maxOffset == int.MaxValue || goal.DistanceSquared(closestGoal) <= maxOffset)            
+            if (maxOffset == int.MaxValue || goal.DistanceSquared(closestGoal) <= Math.Pow(maxOffset, 2))            
                 return ReconstructPath(Came_From, closestGoal);
             else
                 return null;

--- a/MinecraftClient/Mapping/Movement.cs
+++ b/MinecraftClient/Mapping/Movement.cs
@@ -198,7 +198,7 @@ namespace MinecraftClient.Mapping
                     closestGoal = ClosedSet.OrderBy(checkedLocation => checkedLocation.DistanceSquared(goal)).First();
 
                 // Stop when goal is reached or we are close enough
-                if (current == goal || (minOffset > 0 && current.DistanceSquared(goal) <= Math.Pow(minOffset, 2)))
+                if (current == goal || (minOffset > 0 && current.DistanceSquared(goal) <= minOffset))
                     return ReconstructPath(Came_From, current);
                 else if (ct.IsCancellationRequested)
                     break;              // Return if we are cancelled

--- a/MinecraftClient/Mapping/Movement.cs
+++ b/MinecraftClient/Mapping/Movement.cs
@@ -167,6 +167,10 @@ namespace MinecraftClient.Mapping
 
             if (minOffset > maxOffset)
                 throw new ArgumentException("minOffset must be lower or equal to maxOffset", "minOffset");
+            
+            // We always use distance squared so our limits must also be squared.
+            minOffset *= minOffset;
+            maxOffset *= maxOffset;
 
             Location current = new Location(); // Location that is currently processed
             Location closestGoal = new Location(); // Closest Location to the goal. Used for approaching if goal can not be reached or was not found.
@@ -222,7 +226,7 @@ namespace MinecraftClient.Mapping
             }
 
             // Goal could not be reached. Set the path to the closest location if close enough
-            if (maxOffset == int.MaxValue || goal.DistanceSquared(closestGoal) <= Math.Pow(maxOffset, 2))            
+            if (maxOffset == int.MaxValue || goal.DistanceSquared(closestGoal) <= maxOffset)            
                 return ReconstructPath(Came_From, closestGoal);
             else
                 return null;

--- a/MinecraftClient/Mapping/Movement.cs
+++ b/MinecraftClient/Mapping/Movement.cs
@@ -190,8 +190,10 @@ namespace MinecraftClient.Mapping
                     OpenSet.Select(location => f_score.ContainsKey(location)
                     ? new KeyValuePair<Location, int>(location, f_score[location])
                     : new KeyValuePair<Location, int>(location, int.MaxValue))
-                    .OrderBy(pair => pair.Value).First().Key;
-
+                    .OrderBy(pair => pair.Value).
+                    // Sort for h-score (f-score - g-score) to get smallest distance to goal if f-scores are equal
+                    ThenBy(pair => f_score[pair.Key]-g_score[pair.Key]).First().Key;
+                
                 // Only assert a value if it is of actual use later
                 if (maxOffset > 0 && ClosedSet.Count > 0)
                     // Get the block that currently is closest to the goal


### PR DESCRIPTION
We need to square the parameters to be able to actually compare the distance, if we are not willing to generate the root.