### PR TITLE
Scripting Hotfix for .NET

### DIFF
--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -33,6 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
+    <PackageReference Include="SingleFileExtractor.Core" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="config\ChatBots\AutoLook.cs" />

--- a/MinecraftClient/Scripting/DynamicRun/Builder/Compiler.cs
+++ b/MinecraftClient/Scripting/DynamicRun/Builder/Compiler.cs
@@ -7,16 +7,18 @@ https://github.com/laurentkempe/DynamicRun/blob/master/LICENSE
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using MinecraftClient;
+using SingleFileExtractor.Core;
 
 namespace DynamicRun.Builder
 {
-    internal class Compiler
+    internal class Compiler 
     {
         public CompileResult Compile(string filepath, string fileName)
         {
@@ -58,18 +60,103 @@ namespace DynamicRun.Builder
 
             var parsedSyntaxTree = SyntaxFactory.ParseSyntaxTree(codeString, options);
 
+            var mods = Assembly.GetEntryAssembly().GetModules();
+            
+#pragma warning disable IL3000
+            // System.Private.CoreLib
+            var A = typeof(object).Assembly.Location;
+            // System.Console
+            var B = typeof(Console).Assembly.Location;
+            // The path to MinecraftClient.dll
+            var C = typeof(Program).Assembly.Location;
+
             var references = new List<MetadataReference>
             {
-                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
-                MetadataReference.CreateFromFile(typeof(ChatBot).Assembly.Location)
+                MetadataReference.CreateFromFile(A),
+                MetadataReference.CreateFromFile(B)
             };
-            
-            Assembly.GetEntryAssembly()?.GetReferencedAssemblies().ToList()
-                .ForEach(a => references.Add(MetadataReference.CreateFromFile(Assembly.Load(a).Location)));
 
+            // We're on a Single File Application, so we need to extract the executable to get the assembly.
+            if (string.IsNullOrEmpty(C))
+            {
+                // Create a temporary file to copy the executable to.
+                var executableDir = System.AppContext.BaseDirectory;
+                var executablePath = Path.Combine(executableDir, "MinecraftClient.exe");
+                var tempFileName = Path.GetTempFileName();
+                if (File.Exists(executablePath))
+                {
+                    // Copy the executable to a temporary path.
+                    ExecutableReader e = new();
+                    File.Delete(tempFileName);
+                    File.Copy(executablePath, tempFileName);
+                    
+                    // Access the contents of the executable.
+                    var viewAccessor = MemoryMappedFile.CreateFromFile(tempFileName, FileMode.Open).CreateViewAccessor();
+                    var manifest = e.ReadManifest(viewAccessor);
+                    var files = manifest.Files;
+                    
+                    // Find MinecraftClient.dll in the executable.
+                    var assembly = files.FirstOrDefault(x => x.RelativePath == "MinecraftClient.dll");
+
+                    // Check if the executable has the assembly.
+                    if (assembly == null)
+                    {
+                        throw new InvalidOperationException("The executable does not contain the assembly.");
+                    }
+
+                    // Get the assembly from the executable.
+                    Stream? assemblyStream = typeof(BundleExtractor).GetMethod("GetStreamForFileEntry", BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, new object[] { viewAccessor, assembly }) as Stream;
+
+                    // Check if the assembly stream is null.
+                    if (assemblyStream == null)
+                    {
+                        throw new InvalidOperationException("assemblyStream is null");
+                    }
+
+                    // Add the assembly reference.
+                    references.Add(MetadataReference.CreateFromStream(assemblyStream));
+
+                    var assemblyrefs = Assembly.GetEntryAssembly()?.GetReferencedAssemblies().ToList();
+                    
+                    foreach (var refs in assemblyrefs) {
+                        var loadedAssembly = Assembly.Load(refs);
+                        if (string.IsNullOrEmpty(loadedAssembly.Location))
+                        {
+                            // Check if we can access the file from the executable.
+                            var reference = files.FirstOrDefault(x => x.RelativePath.Remove(x.RelativePath.Length - 4) == refs.Name);
+                            var refCount = files.Count(x => x.RelativePath.Remove(x.RelativePath.Length - 4) == refs.Name);
+                            if (refCount > 1)
+                            {
+                                // Safety net for the case where the assembly is referenced multiple times.
+                                // Should not happen normally, but we can make exceptions when it does happen.
+                                throw new InvalidOperationException("Too many references to the same assembly.");
+                            }
+                            if (reference == null)
+                            {
+                                throw new NotImplementedException("Cannot find the assembly from the executable. Executable name: " + refs.Name);
+                            }
+
+                            assemblyStream = typeof(BundleExtractor).GetMethod("GetStreamForFileEntry", BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, new object[] { viewAccessor, reference }) as Stream;
+                            references.Add(MetadataReference.CreateFromStream(assemblyStream));
+                            continue;
+                        }
+                        references.Add(MetadataReference.CreateFromFile(loadedAssembly.Location));
+                    }
+
+                    // Cleanup.
+                    assemblyStream.Dispose();
+                    viewAccessor.Flush();
+                    viewAccessor.Dispose();
+                }
+            }
+            else
+            {
+                references.Add(MetadataReference.CreateFromFile(C));
+                Assembly.GetEntryAssembly()?.GetReferencedAssemblies().ToList().ForEach(a => references.Add(MetadataReference.CreateFromFile(Assembly.Load(a).Location)));
+            }
+#pragma warning restore IL3000
             return CSharpCompilation.Create($"{fileName}.dll",
-                new[] { parsedSyntaxTree }, 
+                new[] { parsedSyntaxTree },
                 references: references, 
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, 
                     optimizationLevel: OptimizationLevel.Release,

--- a/MinecraftClient/Scripting/DynamicRun/Builder/Compiler.cs
+++ b/MinecraftClient/Scripting/DynamicRun/Builder/Compiler.cs
@@ -111,11 +111,11 @@ namespace DynamicRun.Builder
                             {
                                 // Safety net for the case where the assembly is referenced multiple times.
                                 // Should not happen normally, but we can make exceptions when it does happen.
-                                throw new InvalidOperationException("Too many references to the same assembly.");
+                                throw new InvalidOperationException("Too many references to the same assembly. Assembly name: " + refs.Name);
                             }
                             if (reference == null)
                             {
-                                throw new NotImplementedException();
+                                throw new InvalidOperationException("The executable does not contain a referenced assembly. Assembly name: " + refs.Name);
                             }
 
                             assemblyStream = GetStreamForFileEntry(viewAccessor, reference); 


### PR DESCRIPTION
Scripting was inadvertently broken when i turned on [Single File Application](https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli) compilation.

I noticed a peculiar warning while trying to fix the automated builds, warning [IL3000](https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000), about assembly paths being empty on SFAs, originating from `Compiler.cs`. The `MinecraftClient.dll` file is now inaccessible since it is embedded into the executable.

The fix that I have done here is to simply extract the required assemblies from the executable into memory and load them accordingly.