### PR TITLE
Add ARM64 as a precompiled binary release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -23,6 +23,7 @@ jobs:
         echo win-out-path=${{ env.project-path }}/bin/Release/${{ env.target-version }}/win-x64/publish/ >> $GITHUB_ENV
         echo linux-out-path=${{ env.project-path }}/bin/Release/${{ env.target-version }}/linux-x64/publish/ >> $GITHUB_ENV
         echo osx-out-path=${{ env.project-path }}/bin/Release/${{ env.target-version }}/osx-x64/publish/ >> $GITHUB_ENV
+        echo linux-arm64-out-path=${{ env.project-path }}/bin/Release/${{ env.target-version }}/linux-arm64/publish/ >> $GITHUB_ENV
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v2.1.0
@@ -59,6 +60,13 @@ jobs:
     - name: Zip Linux Build
       run: zip -qq -r linux.zip *
       working-directory: ${{ env.linux-out-path }}
+
+    - name: Build for ARM64 Linux
+      run: dotnet publish ${{ env.project-path }}.sln -f ${{ env.target-version }} -r linux-arm64 ${{ env.compile-flags }}
+      
+    - name: Zip ARM64 Linux Build
+      run: zip -qq -r linux-arm64.zip *
+      working-directory: ${{ env.linux-arm64-out-path }}
 
     - name: Build for OSX
       run: dotnet publish ${{ env.project-path }}.sln -f ${{ env.target-version }} -r osx-x64 ${{ env.compile-flags }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -100,6 +100,15 @@ jobs:
         assetName: ${{ env.PROJECT }}-linux.zip
         tag: ${{ format('{0}-{1}', steps.date-release.outputs.time, github.run_number) }}
 
+    - name: Linux ARM64 Release
+      uses: tix-factory/release-manager@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        mode: uploadReleaseAsset
+        filePath: ${{ env.linux-arm64-out-path }}linux.zip
+        assetName: ${{ env.PROJECT }}-linux-arm64.zip
+        tag: ${{ format('{0}-{1}', steps.date-release.outputs.time, github.run_number) }}
+
     - name: OSX Release
       uses: tix-factory/release-manager@v1
       with:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -105,7 +105,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         mode: uploadReleaseAsset
-        filePath: ${{ env.linux-arm64-out-path }}linux.zip
+        filePath: ${{ env.linux-arm64-out-path }}linux-arm64.zip
         assetName: ${{ env.PROJECT }}-linux-arm64.zip
         tag: ${{ format('{0}-{1}', steps.date-release.outputs.time, github.run_number) }}
 


### PR DESCRIPTION
To help reduce the amount of people requiring to build MCC for their ARM servers and devices (i.e. Raspberry Pis and ARM VPSes), we should start adding ARM releases as part of our precompiled builds.

Mentioning @milutinke as requested.