### PR TITLE
Support for using relative coordinates in /move

### DIFF
--- a/MinecraftClient/Command.cs
+++ b/MinecraftClient/Command.cs
@@ -80,7 +80,7 @@ namespace MinecraftClient
         /// <returns>Argument array or empty array if no arguments</returns>
         public static string[] getArgs(string command)
         {
-            string[] args = getArg(command).Split(' ');
+            string[] args = getArg(command).Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (args.Length == 1 && args[0] == "")
             {
                 return new string[] { };

--- a/MinecraftClient/Commands/Move.cs
+++ b/MinecraftClient/Commands/Move.cs
@@ -91,7 +91,7 @@ namespace MinecraftClient.Commands
                     try
                     {
                         Location current = handler.GetCurrentLocation(), currentCenter = new Location(current).ConvertToCenter();
-
+                        
                         double x = args[0].StartsWith('~') ? current.X + (args[0].Length > 1 ? double.Parse(args[0][1..]) : 0) : double.Parse(args[0]);
                         double y = args[1].StartsWith('~') ? current.Y + (args[1].Length > 1 ? double.Parse(args[1][1..]) : 0) : double.Parse(args[1]);
                         double z = args[2].StartsWith('~') ? current.Z + (args[2].Length > 1 ? double.Parse(args[2][1..]) : 0) : double.Parse(args[2]);

--- a/MinecraftClient/Mapping/Location.cs
+++ b/MinecraftClient/Mapping/Location.cs
@@ -50,6 +50,16 @@ namespace MinecraftClient.Mapping
         /// <summary>
         /// Create a new location
         /// </summary>
+        public Location(Location loc)
+        {
+            X = loc.X;
+            Y = loc.Y;
+            Z = loc.Z;
+        }
+
+        /// <summary>
+        /// Create a new location
+        /// </summary>
         /// <param name="chunkX">Location of the chunk into the world</param>
         /// <param name="chunkZ">Location of the chunk into the world</param>
         /// <param name="blockX">Location of the block into the chunk</param>
@@ -67,7 +77,7 @@ namespace MinecraftClient.Mapping
         /// Round coordinates
         /// </summary>
         /// <returns>itself</returns>
-        public Location ToFloor()
+        public Location ConvertToFloor()
         {
             this.X = Math.Floor(this.X);
             this.Y = Math.Floor(this.Y);
@@ -79,7 +89,7 @@ namespace MinecraftClient.Mapping
         /// Get the center coordinates
         /// </summary>
         /// <returns>itself</returns>
-        public Location ToCenter()
+        public Location ConvertToCenter()
         {
             this.X = Math.Floor(this.X) + 0.5;
             this.Z = Math.Floor(this.Z) + 0.5;

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -1102,7 +1102,7 @@ namespace MinecraftClient
         /// <summary>
         /// Move to the specified location
         /// </summary>
-        /// <param name="location">Location to reach</param>
+        /// <param name="goal">Location to reach</param>
         /// <param name="allowUnsafe">Allow possible but unsafe locations thay may hurt the player: lava, cactus...</param>
         /// <param name="allowDirectTeleport">Allow non-vanilla direct teleport instead of computing path, but may cause invalid moves and/or trigger anti-cheat plugins</param>
         /// <param name="maxOffset">If no valid path can be found, also allow locations within specified distance of destination</param>
@@ -1110,21 +1110,21 @@ namespace MinecraftClient
         /// <param name="timeout">How long to wait until the path is evaluated (default: 5 seconds)</param>
         /// <remarks>When location is unreachable, computation will reach timeout, then optionally fallback to a close location within maxOffset</remarks>
         /// <returns>True if a path has been found</returns>
-        public bool MoveTo(Location location, bool allowUnsafe = false, bool allowDirectTeleport = false, int maxOffset = 0, int minOffset = 0, TimeSpan? timeout = null)
+        public bool MoveTo(Location goal, bool allowUnsafe = false, bool allowDirectTeleport = false, int maxOffset = 0, int minOffset = 0, TimeSpan? timeout = null)
         {
             lock (locationLock)
             {
                 if (allowDirectTeleport)
                 {
                     // 1-step path to the desired location without checking anything
-                    UpdateLocation(location, location); // Update yaw and pitch to look at next step
-                    handler.SendLocationUpdate(location, Movement.IsOnGround(world, location), _yaw, _pitch);
+                    UpdateLocation(goal, goal); // Update yaw and pitch to look at next step
+                    handler.SendLocationUpdate(goal, Movement.IsOnGround(world, goal), _yaw, _pitch);
                     return true;
                 }
                 else
                 {
                     // Calculate path through pathfinding. Path contains a list of 1-block movement that will be divided into steps
-                    path = Movement.CalculatePath(world, this.location, location, allowUnsafe, maxOffset, minOffset, timeout ?? TimeSpan.FromSeconds(5));
+                    path = Movement.CalculatePath(world, this.location, goal, allowUnsafe, maxOffset, minOffset, timeout ?? TimeSpan.FromSeconds(5));
                     return path != null;
                 }
             }


### PR DESCRIPTION
resolve #724

Usage:
``/move 1 2 3``
``/move 1.23 4.56 7.89``
``/move ~5 ~1 ~-7``
``/move ~.2 ~.5 ~-.67``
``/move ~.2 63.5 ~-.67``