### PR TITLE
Added a way to execute multiple commands with a single command

### DIFF
--- a/MinecraftClient/Commands/ExecIf.cs
+++ b/MinecraftClient/Commands/ExecIf.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DynamicExpresso;
+
+namespace MinecraftClient.Commands
+{
+    class ExecIf : Command
+    {
+        public override string CmdName { get { return "execif"; } }
+        public override string CmdUsage { get { return "execif <condition/expression> ---> <command>"; } }
+        public override string CmdDesc { get { return "cmd.execif.desc"; } }
+
+        public override string Run(McClient handler, string command, Dictionary<string, object> localVars)
+        {
+            if (hasArg(command))
+            {
+                string commandsString = getArg(command);
+
+                if (!commandsString.Contains("--->"))
+                    return GetCmdDescTranslated();
+
+                string[] parts = commandsString.Split("--->", StringSplitOptions.TrimEntries)
+                    .ToList()
+                    .ConvertAll(command => command.Trim())
+                    .ToArray();
+
+                if (parts.Length == 0)
+                    return GetCmdDescTranslated();
+
+                string expressionText = parts[0];
+                string resultCommand = parts[1];
+
+                try
+                {
+                    var interpreter = new Interpreter();
+                    interpreter.SetVariable("MCC", handler);
+
+                    foreach (KeyValuePair<string, object> entry in Settings.GetVariables())
+                        interpreter.SetVariable(entry.Key, entry.Value);
+
+                    Lambda parsedExpression = interpreter.Parse(expressionText);
+                    var result = parsedExpression.Invoke();
+
+                    if (result != null)
+                    {
+                        bool shouldExec = false;
+
+                        if (result is bool)
+                            shouldExec = (bool)result;
+                        else if (result is string)
+                            shouldExec = !string.IsNullOrEmpty((string)result) && ((string)result).Trim().Contains("true", StringComparison.OrdinalIgnoreCase);
+                        else if (result is int)
+                            shouldExec = (int)result > 0;
+                        else if (result is double)
+                            shouldExec = (double)result > 0;
+                        else if (result is float)
+                            shouldExec = (float)result > 0;
+                        else if (result is Int16)
+                            shouldExec = (Int16)result > 0;
+                        else if (result is Int32)
+                            shouldExec = (Int32)result > 0;
+                        else if (result is Int64)
+                            shouldExec = (Int64)result > 0;
+
+                        handler.Log.Debug("[Execif] Result Type: " + result.GetType().Name);
+
+                        if (shouldExec)
+                        {
+                            string output = "";
+                            handler.PerformInternalCommand(resultCommand, ref output);
+
+                            if (string.IsNullOrEmpty(output))
+                                handler.Log.Debug(Translations.TryGet("cmd.execif.executed_no_output", expressionText, resultCommand));
+                            else handler.Log.Debug(Translations.TryGet("cmd.execif.executed", expressionText, resultCommand, output));
+
+                            return "";
+                        }
+
+                        return "";
+                    }
+                }
+                catch (Exception e)
+                {
+                    handler.Log.Error(Translations.TryGet("cmd.execif.error_occured", command));
+                    handler.Log.Error(Translations.TryGet("cmd.execif.error", e.Message));
+                    return "";
+                }
+
+                return GetCmdDescTranslated();
+            }
+
+            return GetCmdDescTranslated();
+        }
+
+
+    }
+}

--- a/MinecraftClient/Commands/ExecIf.cs
+++ b/MinecraftClient/Commands/ExecIf.cs
@@ -39,14 +39,13 @@ namespace MinecraftClient.Commands
                     foreach (KeyValuePair<string, object> entry in Settings.GetVariables())
                         interpreter.SetVariable(entry.Key, entry.Value);
 
-                    Lambda parsedExpression = interpreter.Parse(expressionText);
-                    var result = parsedExpression.Invoke();
+                    var result = interpreter.Eval<bool>(expressionText);
 
                     if (result != null)
                     {
-                        bool shouldExec = false;
+                        bool shouldExec = result;
 
-                        if (result is bool)
+                        /*if (result is bool)
                             shouldExec = (bool)result;
                         else if (result is string)
                             shouldExec = !string.IsNullOrEmpty((string)result) && ((string)result).Trim().Contains("true", StringComparison.OrdinalIgnoreCase);
@@ -62,6 +61,7 @@ namespace MinecraftClient.Commands
                             shouldExec = (Int32)result > 0;
                         else if (result is Int64)
                             shouldExec = (Int64)result > 0;
+                        */
 
                         handler.Log.Debug("[Execif] Result Type: " + result.GetType().Name);
 

--- a/MinecraftClient/Commands/ExecMulti.cs
+++ b/MinecraftClient/Commands/ExecMulti.cs
@@ -15,10 +15,13 @@ namespace MinecraftClient.Commands
             if (hasArg(command))
             {
                 string commandsString = getArg(command);
-                IEnumerable<string> commands = commandsString.Split("->")
+
+                if (commandsString.Contains("execmulti", StringComparison.OrdinalIgnoreCase) || commandsString.Contains("execif", StringComparison.OrdinalIgnoreCase))
+                    return Translations.TryGet("cmd.execmulti.prevent");
+
+                IEnumerable<string> commands = commandsString.Split("->", StringSplitOptions.TrimEntries)
                     .ToList()
-                    .ConvertAll(command => command.Trim())
-                    .FindAll(command => !string.IsNullOrEmpty(command) || command.StartsWith("execmulti", StringComparison.OrdinalIgnoreCase));
+                    .FindAll(command => !string.IsNullOrEmpty(command));
 
                 foreach (string cmd in commands)
                 {

--- a/MinecraftClient/Commands/ExecMulti.cs
+++ b/MinecraftClient/Commands/ExecMulti.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MinecraftClient.Commands
+{
+    class ExecMulti : Command
+    {
+        public override string CmdName { get { return "execmulti"; } }
+        public override string CmdUsage { get { return "execmulti <command 1> -> <command2> -> <command 3> -> ..."; } }
+        public override string CmdDesc { get { return "cmd.execmulti.desc"; } }
+
+        public override string Run(McClient handler, string command, Dictionary<string, object> localVars)
+        {
+            if (hasArg(command))
+            {
+                string commandsString = getArg(command);
+                IEnumerable<string> commands = commandsString.Split("->")
+                    .ToList()
+                    .ConvertAll(command => command.Trim())
+                    .FindAll(command => !string.IsNullOrEmpty(command) || command.StartsWith("execmulti", StringComparison.OrdinalIgnoreCase));
+
+                foreach (string cmd in commands)
+                {
+                    string output = "";
+                    handler.PerformInternalCommand(cmd, ref output);
+
+                    string log = Translations.TryGet(
+                        "cmd.execmulti.executed", cmd,
+                        string.IsNullOrEmpty(output) ? Translations.TryGet("cmd.execmulti.no_result") : Translations.TryGet("cmd.execmulti.result", output));
+
+                    if (output.Contains("unknown command", StringComparison.OrdinalIgnoreCase))
+                        handler.Log.Error(log);
+                    else handler.Log.Info(log);
+                }
+
+                return "";
+            }
+
+            return GetCmdDescTranslated();
+        }
+    }
+}

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -316,7 +316,7 @@ namespace MinecraftClient
                 {
                     if (e is not ThreadAbortException)
                         Log.Warn("Update: Got error from " + bot.ToString() + ": " + e.ToString());
-                    else 
+                    else
                         throw; //ThreadAbortException should not be caught
                 }
             }
@@ -570,7 +570,7 @@ namespace MinecraftClient
                     {
                         string response_msg = "";
                         string command = Settings.internalCmdChar == ' ' ? text : text.Substring(1);
-                        if (!PerformInternalCommand(Settings.ExpandVars(command), ref response_msg) && Settings.internalCmdChar == '/')
+                        if (!PerformInternalCommand(Settings.ExpandVars(command), ref response_msg, Settings.GetVariables()) && Settings.internalCmdChar == '/')
                         {
                             SendText(text);
                         }
@@ -658,6 +658,7 @@ namespace MinecraftClient
             else if (cmds.ContainsKey(command_name))
             {
                 response_msg = cmds[command_name].Run(this, command, localVars);
+
                 foreach (ChatBot bot in bots.ToArray())
                 {
                     try
@@ -1658,8 +1659,8 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 1;
                                     }
-                                    else if (item != null && item.Count == 1 && (item.Type == ItemType.NetheriteIngot || 
-                                        item.Type == ItemType.Emerald || item.Type == ItemType.Diamond || item.Type == ItemType.GoldIngot || 
+                                    else if (item != null && item.Count == 1 && (item.Type == ItemType.NetheriteIngot ||
+                                        item.Type == ItemType.Emerald || item.Type == ItemType.Diamond || item.Type == ItemType.GoldIngot ||
                                         item.Type == ItemType.IronIngot) && !inventory.Items.ContainsKey(0))
                                     {
                                         lower2upper = true;

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.5.0" />
+    <PackageReference Include="DynamicExpresso.Core" Version="2.13.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0-1.final" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.233001">

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -271,6 +271,12 @@ cmd.entityCmd.distance=Distance
 cmd.entityCmd.location=Location
 cmd.entityCmd.type=Type
 
+# Exec Multi
+cmd.execmulti.desc=Execute multiple commands one after another
+cmd.execmulti.executed=Executed the command '{0}' with {1}
+cmd.execmulti.result=result '{0}'!
+cmd.execmulti.no_result=no result!
+
 # Exit
 cmd.exit.desc=disconnect from the server.
 

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -271,6 +271,13 @@ cmd.entityCmd.distance=Distance
 cmd.entityCmd.location=Location
 cmd.entityCmd.type=Type
 
+# Exec If
+cmd.execif.desc=Allows you to execute a command if a condition is met. (You can use variables from MinecraftClient.ini and /set command, as well as CSharp expressions)
+cmd.execif.executed=The condition '{0}' was met, executed command '{1}' with result '{2}'.
+cmd.execif.executed_no_output=The condition '{0}' was met, executed command '{1}', no result was returned.
+cmd.execif.error_occured=An error has occured while executing the command: {0}
+cmd.execif.error=Error: {0}
+
 # Exec Multi
 cmd.execmulti.desc=Execute multiple commands one after another
 cmd.execmulti.executed=Executed the command '{0}' with {1}

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -1006,6 +1006,15 @@ namespace MinecraftClient
         }
 
         /// <summary>
+        /// Get a dictionary containing variables (names and value)
+        /// </summary>
+        /// <returns>A IDictionary<string, object> containing a name and a vlaue key pairs of variables</returns>
+        public static Dictionary<string, object> GetVariables()
+        {
+            return AppVars;
+        }
+
+        /// <summary>
         /// Replace %variables% with their value from global AppVars
         /// </summary>
         /// <param name="str">String to parse</param>


### PR DESCRIPTION
Added a way to execute multiple commands with a single command with:
```
/execmulti <command 1> -> <command 2> -> <command 3> -> ...
```

Another idea, we could implement a field in `PerformInternalCommand` which would indicate a failure of the execution, so we could make a `/chain` command which would stop if one of the commands has failed to execute, this could be useful in some scenarios, tho this would be a bit tricky to implement and to keep backwards compatibility.