### PR TITLE
Fully implemented Map Data packet + Fixed 1.14 not working.

### DIFF
--- a/MinecraftClient/Mapping/MapIcon.cs
+++ b/MinecraftClient/Mapping/MapIcon.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MinecraftClient.Protocol.Handlers;
+
+namespace MinecraftClient.Mapping
+{
+    public class MapIcon
+    {
+        public MapIconType Type { set; get; }
+        public byte X { set; get; }
+        public byte Z { set; get; }
+        public byte Direction { set; get; }
+        public string? DisplayName { set; get; } = null;
+    }
+}

--- a/MinecraftClient/Mapping/MapIconType.cs
+++ b/MinecraftClient/Mapping/MapIconType.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MinecraftClient.Mapping
+{
+    public enum MapIconType
+    {
+        White_Arrow = 0,
+        Green_Arrow,
+        Red_Arrow,
+        Blue_Arrow,
+        White_Cross,
+        Red_Pointer,
+        White_Circle,
+        Small_White_Circle,
+        Mansion,
+        Temple,
+        White_Banner,
+        Orange_Banner,
+        Magenta_Banner,
+        Light_Blue_Banner,
+        Yellow_Banner,
+        Lime_Banner,
+        Pink_Banner,
+        Gray_Banner,
+        Light_Gray_Banner,
+        Cyan_Banner,
+        Purple_Banner,
+        Blue_Banner,
+        Brown_Banner,
+        Green_Banner,
+        Red_Banner,
+        Black_Banner,
+        Treasure_Marker
+    }
+}

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -3063,16 +3063,22 @@ namespace MinecraftClient
         }
 
         /// <summary>
-        /// Called map data
+        /// Called when an update of the map is sent by the server, take a look at https://wiki.vg/Protocol#Map_Data for more info on the fields
+        /// Map format and colors: https://minecraft.fandom.com/wiki/Map_item_format
         /// </summary>
-        /// <param name="mapid"></param>
-        /// <param name="scale"></param>
-        /// <param name="trackingposition"></param>
-        /// <param name="locked"></param>
-        /// <param name="iconcount"></param>
-        public void OnMapData(int mapid, byte scale, bool trackingposition, bool locked, int iconcount)
+        /// <param name="mapid">Map ID of the map being modified</param>
+        /// <param name="scale">A scale of the Map, from 0 for a fully zoomed-in map (1 block per pixel) to 4 for a fully zoomed-out map (16 blocks per pixel)</param>
+        /// <param name="trackingposition">Specifies whether player and item frame icons are shown </param>
+        /// <param name="locked">True if the map has been locked in a cartography table </param>
+        /// <param name="icons">A list of MapIcon objects of map icons, send only if trackingPosition is true</param>
+        /// <param name="columnsUpdated">Numbs of columns that were updated (map width) (NOTE: If it is 0, the next fields are not used/are set to default values of 0 and null respectively)</param>
+        /// <param name="rowsUpdated">Map height</param>
+        /// <param name="mapCoulmnX">x offset of the westernmost column</param>
+        /// <param name="mapRowZ">z offset of the northernmost row</param>
+        /// <param name="colors">a byte array of colors on the map</param>
+        public void OnMapData(int mapid, byte scale, bool trackingPosition, bool locked, List<MapIcon> icons, byte columnsUpdated, byte rowsUpdated, byte mapCoulmnX, byte mapCoulmnZ, byte[]? colors)
         {
-            DispatchBotEvent(bot => bot.OnMapData(mapid, scale, trackingposition, locked, iconcount));
+            DispatchBotEvent(bot => bot.OnMapData(mapid, scale, trackingPosition, locked, icons, columnsUpdated, rowsUpdated, mapCoulmnX, mapCoulmnZ, colors));
         }
 
         /// <summary>

--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -584,6 +584,7 @@ namespace MinecraftClient.Protocol.Handlers
         {
             Dictionary<int, object?> data = new();
             byte key = ReadNextByte(cache);
+
             while (key != 0xff)
             {
                 int type = ReadNextVarInt(cache);
@@ -599,6 +600,7 @@ namespace MinecraftClient.Protocol.Handlers
                         type += 1;
                     }
                 }
+
                 // Value's data type is depended on Type
                 object? value = null;
 

--- a/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
+++ b/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
@@ -62,7 +62,7 @@ namespace MinecraftClient.Protocol.Handlers
                 p = new PacketPalette112();
             else if (protocol <= Protocol18Handler.MC_1_12_2_Version)
                 p = new PacketPalette1122();
-            else if (protocol <= Protocol18Handler.MC_1_14_Version)
+            else if (protocol < Protocol18Handler.MC_1_14_Version)
                 p = new PacketPalette113();
             else if (protocol <= Protocol18Handler.MC_1_15_Version)
                 p = new PacketPalette114();

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -4,23 +4,22 @@ using System.Linq;
 using System.Text;
 using System.Net.Sockets;
 using System.Threading;
+using System.Security.Cryptography;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using System.Collections.Concurrent;
 using MinecraftClient.Crypto;
 using MinecraftClient.Proxy;
-using System.Security.Cryptography;
 using MinecraftClient.Mapping;
 using MinecraftClient.Mapping.BlockPalettes;
 using MinecraftClient.Mapping.EntityPalettes;
 using MinecraftClient.Protocol.Handlers.Forge;
 using MinecraftClient.Inventory;
-using System.Diagnostics;
 using MinecraftClient.Inventory.ItemPalettes;
 using MinecraftClient.Protocol.Handlers.PacketPalettes;
 using MinecraftClient.Logger;
-using System.Threading.Tasks;
 using MinecraftClient.Protocol.Keys;
-using System.Text.RegularExpressions;
 using MinecraftClient.Protocol.Session;
-using System.Collections.Concurrent;
 using MinecraftClient.Protocol.Message;
 
 namespace MinecraftClient.Protocol.Handlers
@@ -45,6 +44,7 @@ namespace MinecraftClient.Protocol.Handlers
         internal const int MC_1_12_Version = 335;
         internal const int MC_1_12_2_Version = 340;
         internal const int MC_1_13_Version = 393;
+        internal const int MC_1_13_2_Version = 404;
         internal const int MC_1_14_Version = 477;
         internal const int MC_1_15_Version = 573;
         internal const int MC_1_15_2_Version = 578;
@@ -781,23 +781,42 @@ namespace MinecraftClient.Protocol.Handlers
                             }
                             break;
                         case PacketTypesIn.MapData:
+                            if (protocolVersion < MC_1_8_Version)
+                                break;
+
                             int mapid = dataTypes.ReadNextVarInt(packetData);
                             byte scale = dataTypes.ReadNextByte(packetData);
-                            bool trackingPosition = protocolVersion >= MC_1_17_Version ? false : dataTypes.ReadNextBool(packetData);
+
+
+                            // 1.9 +
+                            bool trackingPosition = true;
+
+                            // 1.14+
                             bool locked = false;
-                            if (protocolVersion >= MC_1_14_Version)
-                            {
-                                locked = dataTypes.ReadNextBool(packetData);
-                            }
+
+                            // 1.17+ (locked and trackingPosition switched places)
                             if (protocolVersion >= MC_1_17_Version)
                             {
-                                trackingPosition = dataTypes.ReadNextBool(packetData);
+                                if (protocolVersion >= MC_1_14_Version)
+                                    locked = dataTypes.ReadNextBool(packetData);
+
+                                if (protocolVersion >= MC_1_9_Version)
+                                    trackingPosition = dataTypes.ReadNextBool(packetData);
+                            }
+                            else
+                            {
+                                if (protocolVersion >= MC_1_9_Version)
+                                    trackingPosition = dataTypes.ReadNextBool(packetData);
+
+                                if (protocolVersion >= MC_1_14_Version)
+                                    locked = dataTypes.ReadNextBool(packetData);
                             }
 
                             int iconcount = 0;
                             List<MapIcon> icons = new();
 
-                            if (trackingPosition)
+                            // 1,9 + = needs tracking position to be true to get the icons
+                            if (protocolVersion > MC_1_9_Version ? trackingPosition : true)
                             {
                                 iconcount = dataTypes.ReadNextVarInt(packetData);
 
@@ -805,14 +824,43 @@ namespace MinecraftClient.Protocol.Handlers
                                 {
                                     MapIcon mapIcon = new();
 
-                                    mapIcon.Type = (MapIconType)dataTypes.ReadNextVarInt(packetData);
+                                    // 1.8 - 1.13
+                                    if (protocolVersion < MC_1_13_2_Version)
+                                    {
+                                        byte directionAndtype = dataTypes.ReadNextByte(packetData);
+                                        byte direction, type;
+
+                                        // 1.12.2+
+                                        if (protocolVersion >= MC_1_12_2_Version)
+                                        {
+                                            direction = (byte)(directionAndtype & 0xF);
+                                            type = (byte)((directionAndtype >> 4) & 0xF);
+                                        }
+                                        else // 1.8 - 1.12
+                                        {
+                                            direction = (byte)((directionAndtype >> 4) & 0xF);
+                                            type = (byte)(directionAndtype & 0xF);
+                                        }
+
+                                        mapIcon.Type = (MapIconType)type;
+                                        mapIcon.Direction = direction;
+                                    }
+
+                                    // 1.13.2+
+                                    if (protocolVersion >= MC_1_13_2_Version)
+                                        mapIcon.Type = (MapIconType)dataTypes.ReadNextVarInt(packetData);
+
                                     mapIcon.X = dataTypes.ReadNextByte(packetData);
                                     mapIcon.Z = dataTypes.ReadNextByte(packetData);
-                                    mapIcon.Direction = dataTypes.ReadNextByte(packetData);
-                                    bool mapIconHasDisplayName = dataTypes.ReadNextBool(packetData);
 
-                                    if (mapIconHasDisplayName)
-                                        mapIcon.DisplayName = ChatParser.ParseText(dataTypes.ReadNextString(packetData));
+                                    // 1.13.2+
+                                    if (protocolVersion >= MC_1_13_2_Version)
+                                    {
+                                        mapIcon.Direction = dataTypes.ReadNextByte(packetData);
+
+                                        if (dataTypes.ReadNextBool(packetData)) // Has Display Name?
+                                            mapIcon.DisplayName = ChatParser.ParseText(dataTypes.ReadNextString(packetData));
+                                    }
 
                                     icons.Add(mapIcon);
                                 }

--- a/MinecraftClient/Protocol/IMinecraftComHandler.cs
+++ b/MinecraftClient/Protocol/IMinecraftComHandler.cs
@@ -112,7 +112,7 @@ namespace MinecraftClient.Protocol
         /// This method is called when the protocol handler receives a title
         /// </summary>
         void OnTitle(int action, string titletext, string subtitletext, string actionbartext, int fadein, int stay, int fadeout, string json);
-        
+
         /// <summary>
         /// Called when receiving a connection keep-alive from the server
         /// </summary>
@@ -216,7 +216,7 @@ namespace MinecraftClient.Protocol
         /// </summary>
         /// <param name="entity">Spawned entity</param>
         void OnSpawnEntity(Entity entity);
-        
+
         /// <summary>
         /// Called when an entity has spawned
         /// </summary>
@@ -224,7 +224,7 @@ namespace MinecraftClient.Protocol
         /// <param name="slot">Equipment slot. 0: main hand, 1: off hand, 2–5: armor slot (2: boots, 3: leggings, 4: chestplate, 5: helmet)/param>
         /// <param name="item">Item/param>
         void OnEntityEquipment(int entityid, int slot, Item item);
-        
+
         /// <summary>
         /// Called when a player spawns or enters the client's render distance
         /// </summary>
@@ -312,7 +312,7 @@ namespace MinecraftClient.Protocol
         /// <param name="entityID">Entity ID</param>
         /// <param name="health">The health of the entity</param>
         void OnEntityHealth(int entityID, float health);
-        
+
         /// <summary>
         /// Called when entity metadata or metadata changed.
         /// </summary>
@@ -334,14 +334,14 @@ namespace MinecraftClient.Protocol
         /// <param name="uuid">Affected player's UUID</param>
         /// <param name="gamemode">New game mode</param>
         void OnGamemodeUpdate(Guid uuid, int gamemode);
-        
+
         /// <summary>
         /// Called when a player's latency has changed
         /// </summary>
         /// <param name="uuid">Affected player's UUID</param>
         /// <param name="latency">latency</param>
         void OnLatencyUpdate(Guid uuid, int latency);
-        
+
         /// <summary>
         /// Called when Experience bar is updated
         /// </summary>
@@ -356,17 +356,23 @@ namespace MinecraftClient.Protocol
         /// <remarks>Used for setting player slot after joining game</remarks>
         /// <param name="slot"></param>
         void OnHeldItemChange(byte slot);
-        
+
         /// <summary>
-        /// Called map data
+        /// Called when an update of the map is sent by the server, take a look at https://wiki.vg/Protocol#Map_Data for more info on the fields
+        /// Map format and colors: https://minecraft.fandom.com/wiki/Map_item_format
         /// </summary>
-        /// <param name="mapid"></param>
-        /// <param name="scale"></param>
-        /// <param name="trackingposition"></param>
-        /// <param name="locked"></param>
-        /// <param name="iconcount"></param>
-        void OnMapData(int mapid, byte scale, bool trackingposition, bool locked, int iconcount);
-        
+        /// <param name="mapid">Map ID of the map being modified</param>
+        /// <param name="scale">A scale of the Map, from 0 for a fully zoomed-in map (1 block per pixel) to 4 for a fully zoomed-out map (16 blocks per pixel)</param>
+        /// <param name="trackingposition">Specifies whether player and item frame icons are shown </param>
+        /// <param name="locked">True if the map has been locked in a cartography table </param>
+        /// <param name="icons">A list of MapIcon objects of map icons, send only if trackingPosition is true</param>
+        /// <param name="columnsUpdated">Numbs of columns that were updated (map width) (NOTE: If it is 0, the next fields are not used/are set to default values of 0 and null respectively)</param>
+        /// <param name="rowsUpdated">Map height</param>
+        /// <param name="mapCoulmnX">x offset of the westernmost column</param>
+        /// <param name="mapRowZ">z offset of the northernmost row</param>
+        /// <param name="colors">a byte array of colors on the map</param>
+        void OnMapData(int mapid, byte scale, bool trackingPosition, bool locked, List<MapIcon> icons, byte columnsUpdated, byte rowsUpdated, byte mapCoulmnX, byte mapRowZ, byte[]? colors);
+
         /// <summary>
         /// Called when the Player entity ID has been received from the server
         /// </summary>
@@ -393,7 +399,7 @@ namespace MinecraftClient.Protocol
         /// <param name="objectivevalue">Only if mode is 0 or 2. The text to be displayed for the score</param>
         /// <param name="type">Only if mode is 0 or 2. 0 = "integer", 1 = "hearts".</param>
         void OnScoreboardObjective(string objectivename, byte mode, string objectivevalue, int type);
-        
+
         /// <summary>
         /// Called when DisplayScoreboard
         /// </summary>

--- a/MinecraftClient/Scripting/ChatBot.cs
+++ b/MinecraftClient/Scripting/ChatBot.cs
@@ -145,7 +145,7 @@ namespace MinecraftClient
         /// <param name="text">Text from the server</param>
         /// <param name="json">Raw JSON from the server. This parameter will be NULL on MC 1.5 or lower!</param>
         public virtual void GetText(string text, string? json) { }
-        
+
         /// <summary>
         /// Is called when the client has been disconnected fom the server
         /// </summary>
@@ -245,7 +245,7 @@ namespace MinecraftClient
         /// <param name="uuid">Player UUID</param>
         /// <param name="gamemode">New Game Mode (0: Survival, 1: Creative, 2: Adventure, 3: Spectator).</param>
         public virtual void OnGamemodeUpdate(string playername, Guid uuid, int gamemode) { }
-        
+
         /// <summary>
         /// Called when the Latency has been updated for a player
         /// </summary>
@@ -253,7 +253,7 @@ namespace MinecraftClient
         /// <param name="uuid">Player UUID</param>
         /// <param name="latency">Latency.</param>
         public virtual void OnLatencyUpdate(string playername, Guid uuid, int latency) { }
-        
+
         /// <summary>
         /// Called when the Latency has been updated for a player
         /// </summary>
@@ -262,16 +262,22 @@ namespace MinecraftClient
         /// <param name="uuid">Player UUID</param>
         /// <param name="latency">Latency.</param>
         public virtual void OnLatencyUpdate(Entity entity, string playername, Guid uuid, int latency) { }
-        
+
         /// <summary>
-        /// Called when a map was updated
+        /// Called when an update of the map is sent by the server, take a look at https://wiki.vg/Protocol#Map_Data for more info on the fields
+        /// Map format and colors: https://minecraft.fandom.com/wiki/Map_item_format
         /// </summary>
-        /// <param name="mapid"></param>
-        /// <param name="scale"></param>
-        /// <param name="trackingposition"></param>
-        /// <param name="locked"></param>
-        /// <param name="iconcount"></param>
-        public virtual void OnMapData(int mapid, byte scale, bool trackingposition, bool locked, int iconcount) { }
+        /// <param name="mapid">Map ID of the map being modified</param>
+        /// <param name="scale">A scale of the Map, from 0 for a fully zoomed-in map (1 block per pixel) to 4 for a fully zoomed-out map (16 blocks per pixel)</param>
+        /// <param name="trackingposition">Specifies whether player and item frame icons are shown </param>
+        /// <param name="locked">True if the map has been locked in a cartography table </param>
+        /// <param name="icons">A list of MapIcon objects of map icons, send only if trackingPosition is true</param>
+        /// <param name="columnsUpdated">Numbs of columns that were updated (map width) (NOTE: If it is 0, the next fields are not used/are set to default values of 0 and null respectively)</param>
+        /// <param name="rowsUpdated">Map height</param>
+        /// <param name="mapCoulmnX">x offset of the westernmost column</param>
+        /// <param name="mapRowZ">z offset of the northernmost row</param>
+        /// <param name="colors">a byte array of colors on the map</param>
+        public virtual void OnMapData(int mapid, byte scale, bool trackingPosition, bool locked, List<MapIcon> icons, byte columnsUpdated, byte rowsUpdated, byte mapCoulmnX, byte mapRowZ, byte[]? colors) { }
 
         /// <summary>
         /// Called when tradeList is received from server
@@ -319,7 +325,7 @@ namespace MinecraftClient
         /// <param name="objectivevalue">Only if mode is 0 or 2. The text to be displayed for the score</param>
         /// <param name="type">Only if mode is 0 or 2. 0 = "integer", 1 = "hearts".</param>
         public virtual void OnScoreboardObjective(string objectivename, byte mode, string objectivevalue, int type, string json) { }
-        
+
         /// <summary>
         /// Called when a scoreboard updated
         /// </summary>
@@ -360,12 +366,12 @@ namespace MinecraftClient
         /// <param name="uuid">UUID of the player</param>
         /// <param name="name">Name of the player</param>
         public virtual void OnPlayerLeave(Guid uuid, string? name) { }
-        
+
         /// <summary>
         /// Called when the player deaths
         /// </summary>
         public virtual void OnDeath() { }
-        
+
         /// <summary>
         /// Called when the player respawns
         /// </summary>
@@ -451,14 +457,14 @@ namespace MinecraftClient
         /// </summary>
         public static string GetVerbatim(string text)
         {
-            if ( String.IsNullOrEmpty(text) )
+            if (String.IsNullOrEmpty(text))
                 return String.Empty;
 
             int idx = 0;
             var data = new char[text.Length];
 
-            for ( int i = 0; i < text.Length; i++ )
-                if ( text[i] != '§' )
+            for (int i = 0; i < text.Length; i++)
+                if (text[i] != '§')
                     data[idx++] = text[i];
                 else
                     i++;
@@ -478,7 +484,7 @@ namespace MinecraftClient
                 if (!((c >= 'a' && c <= 'z')
                         || (c >= 'A' && c <= 'Z')
                         || (c >= '0' && c <= '9')
-                        || c == '_') )
+                        || c == '_'))
                     return false;
 
             return true;
@@ -950,7 +956,7 @@ namespace MinecraftClient
                 return Handler.GetWorld();
             return null;
         }
-        
+
         /// <summary>
         /// Get all Entities
         /// </summary>
@@ -968,7 +974,7 @@ namespace MinecraftClient
         {
             return Handler.GetPlayersLatency();
         }
-        
+
         /// <summary>
         /// Get the current location of the player (Feet location)
         /// </summary>
@@ -1002,7 +1008,7 @@ namespace MinecraftClient
         {
             return Handler.ClientIsMoving();
         }
-        
+
         /// <summary>
         /// Look at the specified location
         /// </summary>
@@ -1086,7 +1092,7 @@ namespace MinecraftClient
         {
             return Handler.GetUsername();
         }
-        
+
         /// <summary>
         /// Return the Gamemode of the current account
         /// </summary>
@@ -1361,7 +1367,7 @@ namespace MinecraftClient
         {
             return Handler.GetCurrentSlot();
         }
-        
+
         /// <summary>
         /// Clean all inventory
         /// </summary>
@@ -1370,7 +1376,7 @@ namespace MinecraftClient
         {
             return Handler.ClearInventories();
         }
-        
+
         /// <summary>
         /// Update sign text
         /// </summary>
@@ -1410,7 +1416,7 @@ namespace MinecraftClient
         {
             return Handler.SpectateByUUID(UUID);
         }
-        
+
         /// <summary>
         /// Update command block
         /// </summary>
@@ -1456,7 +1462,7 @@ namespace MinecraftClient
         {
             return Handler.GetMaxChatMessageLength();
         }
-        
+
         /// <summary>
         /// Respawn player
         /// </summary>


### PR DESCRIPTION
This will allow us to process map data and render maps into images with a chat bot, so people can solve those annoying captchas.
However, we need to figure out how the maps are being rendered,

Packet info: https://wiki.vg/Protocol#Map_Data
Map Data format: https://minecraft.fandom.com/wiki/Map_item_format (*NOTE: Colors on the wiki are outdated, we will have to look at the code*)
Minecraft Classes:
 - Packet class: `net.minecraft.network.protocol.game.ClientboundMapItemDataPacket`
 - Map Data class: `net.minecraft.world.level.saveddata.maps.MapItemSavedData`

Found some libraries for reference (a bit dated tho):
 - https://github.com/LB--/MCModify/blob/java/src/main/java/com/lb_stuff/mcmodify/minecraft/Map.java
 - https://github.com/spookymushroom/minecraftmap/blob/master/minecraftmap/__init__.py
 - https://github.com/joodicator/mcmapimg/blob/master/mcmapimg/mcmapimg.py

My proposal is making a chat bot that will hold a cache of all maps being sent, and then when you need to see them, you can render all, a single map or newest N maps.
As for the term `rendering` I am referring to rendering and saving images in a folder, rather than trying to display them in the console somehow.