### PR TITLE
Reload Settings and Chat Bots, Fixed PlayerListLogger Chat Bot, added %datetime%

### DIFF
--- a/MinecraftClient/ChatBots/AutoFishing.cs
+++ b/MinecraftClient/ChatBots/AutoFishing.cs
@@ -54,29 +54,6 @@ namespace MinecraftClient.ChatBots
                 LogToConsoleTranslated("bot.autoFish.no_inv_handle");
         }
 
-        /// <summary>
-        /// Update settings when reloaded
-        /// </summary>
-        public /* override */ void OnSettingsReload()
-        {
-            if (Settings.AutoFishing_Enabled)
-            {
-                if (!GetEntityHandlingEnabled())
-                {
-                    LogToConsoleTranslated("extra.entity_required");
-                    state = FishingState.WaitJoinGame;
-                }
-                inventoryEnabled = GetInventoryEnabled();
-                if (!inventoryEnabled)
-                    LogToConsoleTranslated("bot.autoFish.no_inv_handle");
-            }
-            else
-            {
-                UnloadBot();
-                return;
-            }
-        }
-
         private void StartFishing()
         {
             isFishing = false;
@@ -262,7 +239,7 @@ namespace MinecraftClient.ChatBots
                 if (Settings.AutoFishing_LogFishingBobber)
                     LogToConsole(string.Format("FishingBobber {0}  Dx={1:0.000000} Dy={2:0.000000} Dz={3:0.000000}", Pos, Dx, Math.Abs(Dy), Dz));
 
-                if (Math.Abs(Dx) < Math.Abs(Settings.AutoFishing_StationaryThreshold) && 
+                if (Math.Abs(Dx) < Math.Abs(Settings.AutoFishing_StationaryThreshold) &&
                     Math.Abs(Dz) < Math.Abs(Settings.AutoFishing_StationaryThreshold) &&
                     Math.Abs(Dy) > Math.Abs(Settings.AutoFishing_HookThreshold))
                 {

--- a/MinecraftClient/ChatBots/BotsCommand.cs
+++ b/MinecraftClient/ChatBots/BotsCommand.cs
@@ -1,0 +1,76 @@
+using MinecraftClient.Mapping;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MinecraftClient.Commands
+{
+    class BotsCommand : Command
+    {
+        public override string CmdName { get { return "bots"; } }
+        public override string CmdUsage { get { return "bots [list|unload <bot name|all>]"; } }
+        public override string CmdDesc { get { return "cmd.bots.desc"; } }
+
+        public override string Run(McClient handler, string command, Dictionary<string, object> localVars)
+        {
+            if (hasArg(command))
+            {
+                string[] args = getArgs(command);
+
+                if (args.Length == 1)
+                {
+                    if (args[0].Equals("list", StringComparison.OrdinalIgnoreCase))
+                    {
+                        StringBuilder sb = new();
+
+                        int length = handler.GetLoadedChatBots().Count;
+
+                        if (length == 0)
+                            return Translations.TryGet("cmd.bots.noloaded");
+
+                        for (int i = 0; i < length; i++)
+                        {
+                            sb.Append(handler.GetLoadedChatBots()[i].GetType().Name);
+
+                            if (i != length - 1)
+                                sb.Append(" ,");
+
+                        }
+
+                        return Translations.Get("cmd.bots.list") + ": " + sb.ToString();
+                    }
+
+                }
+                else if (args.Length == 2)
+                {
+                    if (args[0].Equals("unload", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string botName = args[1].Trim();
+
+                        if (botName.ToLower().Equals("all", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (handler.GetLoadedChatBots().Count == 0)
+                                return Translations.TryGet("cmd.bots.noloaded");
+
+                            handler.UnloadAllBots();
+                            return Translations.TryGet("cmd.bots.unloaded_all");
+                        }
+                        else
+                        {
+                            ChatBot? bot = handler.GetLoadedChatBots().Find(bot => bot.GetType().Name.ToLower() == botName.ToLower());
+
+                            if (bot == null)
+                                return Translations.TryGet("cmd.bots.notfound", botName);
+
+                            handler.BotUnLoad(bot);
+                            return Translations.TryGet("cmd.bots.unloaded", botName);
+                        }
+                    }
+                }
+            }
+
+            return GetCmdDescTranslated();
+        }
+    }
+}

--- a/MinecraftClient/ChatBots/PlayerListLogger.cs
+++ b/MinecraftClient/ChatBots/PlayerListLogger.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace MinecraftClient.ChatBots
 {
@@ -34,19 +35,26 @@ namespace MinecraftClient.ChatBots
             count++;
             if (count == timeping)
             {
-                SendText("/list");
-                count = 0;
-            }
-        }
+                string[] playerList = GetOnlinePlayers();
 
-        public override void GetText(string text)
-        {
-            if (text.Contains("Joueurs en ligne") || text.Contains("Connected:") || text.Contains("online:"))
-            {
-                LogToConsole("Saving Player List");
+                StringBuilder sb = new StringBuilder();
+
+                for (int i = 0; i < playerList.Length; i++)
+                {
+                    sb.Append(playerList[i]);
+
+                    // Do not add a comma after the last username
+                    if (i != playerList.Length - 1)
+                        sb.Append(", ");
+                }
+
+                LogDebugToConsole("Saving Player List");
+
                 DateTime now = DateTime.Now;
                 string TimeStamp = "[" + now.Year + '/' + now.Month + '/' + now.Day + ' ' + now.Hour + ':' + now.Minute + ']';
-                System.IO.File.AppendAllText(file, TimeStamp + "\n" + GetVerbatim(text) + "\n\n");
+                System.IO.File.AppendAllText(file, TimeStamp + "\n" + sb.ToString() + "\n\n");
+
+                count = 0;
             }
         }
     }

--- a/MinecraftClient/ChatBots/Reload.cs
+++ b/MinecraftClient/ChatBots/Reload.cs
@@ -1,0 +1,27 @@
+using MinecraftClient.Mapping;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MinecraftClient.Commands
+{
+    class Reload : Command
+    {
+        public override string CmdName { get { return "reload"; } }
+        public override string CmdUsage { get { return "reload"; } }
+        public override string CmdDesc { get { return "cmd.reload.desc"; } }
+
+        public override string Run(McClient handler, string command, Dictionary<string, object> localVars)
+        {
+            handler.Log.Info(Translations.TryGet("cmd.reload.started"));
+            handler.ReloadSettings();
+            handler.Log.Warn(Translations.TryGet("cmd.reload.warning1"));
+            handler.Log.Warn(Translations.TryGet("cmd.reload.warning2"));
+            handler.Log.Warn(Translations.TryGet("cmd.reload.warning3"));
+            handler.Log.Warn(Translations.TryGet("cmd.reload.warning4"));
+
+            return Translations.TryGet("cmd.reload.finished");
+        }
+    }
+}

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -287,6 +287,7 @@ namespace MinecraftClient
             if (Settings.AutoCraft_Enabled) { BotLoad(new AutoCraft(Settings.AutoCraft_configFile)); }
             if (Settings.AutoDrop_Enabled) { BotLoad(new AutoDrop(Settings.AutoDrop_Mode, Settings.AutoDrop_items)); }
             if (Settings.ReplayMod_Enabled && reload) { BotLoad(new ReplayCapture(Settings.ReplayMod_BackupInterval)); }
+            if (Settings.FollowPlayer_Enabled) { BotLoad(new FollowPlayer(Settings.FollowPlayer_UpdateLimit, Settings.FollowPlayer_UpdateLimit)); }
 
             //Add your ChatBot here by uncommenting and adapting
             //BotLoad(new ChatBots.YourBot());

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -46,6 +46,7 @@ namespace MinecraftClient
 
         private static Tuple<Thread, CancellationTokenSource>? offlinePrompt = null;
         private static bool useMcVersionOnce = false;
+        private static string? settingsIniPath = null;
 
         /// <summary>
         /// The main entry point of Minecraft Console Client
@@ -104,10 +105,13 @@ namespace MinecraftClient
                 ConsoleIO.DebugReadInput();
             }
 
+            settingsIniPath = "MinecraftClient.ini";
+
             //Process ini configuration file
             if (args.Length >= 1 && System.IO.File.Exists(args[0]) && Settings.ToLowerIfNeed(Path.GetExtension(args[0])) == ".ini")
             {
                 Settings.LoadFile(args[0]);
+                settingsIniPath = args[0];
 
                 //remove ini configuration file from arguments array
                 List<string> args_tmp = args.ToList<string>();
@@ -527,6 +531,15 @@ namespace MinecraftClient
                 failureMessage += Translations.Get(failureReason);
                 HandleFailure(failureMessage, false, ChatBot.DisconnectReason.LoginRejected);
             }
+        }
+
+        /// <summary>
+        /// Reloads settings
+        /// </summary>
+        public static void ReloadSettings()
+        {
+            if (settingsIniPath != null)
+                Settings.LoadFile(settingsIniPath);
         }
 
         /// <summary>

--- a/MinecraftClient/Resources/config/MinecraftClient.ini
+++ b/MinecraftClient/Resources/config/MinecraftClient.ini
@@ -278,6 +278,7 @@ update_limit=10                   # The rate at which the bot does calculations 
 stop_at_distance=3                # Do not follow the player if he is in the range of 3 blocks (prevents the bot from pushing a player in an infinite loop)
 
 [PlayerListLogger]
+# Log the list of players periodically into a textual file
 enabled=false
 log_file=playerlog.txt
 log_delay=600                     # 10 = 1s

--- a/MinecraftClient/Resources/config/MinecraftClient.ini
+++ b/MinecraftClient/Resources/config/MinecraftClient.ini
@@ -276,3 +276,8 @@ backupinterval=300                # How long should replay file be auto-saved, i
 enabled=false
 update_limit=10                   # The rate at which the bot does calculations (10 = 1s) (Default: 5) (You can tweak this if you feel the bot is too slow)
 stop_at_distance=3                # Do not follow the player if he is in the range of 3 blocks (prevents the bot from pushing a player in an infinite loop)
+
+[PlayerListLogger]
+enabled=false
+log_file=playerlog.txt
+log_delay=600                     # 10 = 1s

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -223,6 +223,14 @@ general.available_cmd=Available commands: {0}
 # Animation
 cmd.animation.desc=Swing your arm.
 
+# Bots
+cmd.bots.desc=List bots, unload a bot or all bots.
+cmd.bots.list=Loaded bots
+cmd.bots.notfound=Bot {0} is not loaded, check if you have made a typo!
+cmd.bots.noloaded=No bots loaded!
+cmd.bots.unloaded=Successfully unloaded bot: {0}
+cmd.bots.unloaded_all=Successfully unloaded all bots!
+
 # ChangeSlot
 cmd.changeSlot.desc=Change slot in hotbar
 cmd.changeSlot.nan=Could not change slot: Not a Number
@@ -364,6 +372,15 @@ cmd.move.chunk_not_loaded=The chunk where the target location resides has not ye
 
 # Reco
 cmd.reco.desc=restart and reconnect to the server.
+
+# Reload
+cmd.reload.started=Reloading settings...
+cmd.reload.warning1=This command will NOT affect certain settings which are used before connecting to a server!
+cmd.reload.warning2=Some settings passed through the command line parameters might get overriden!
+cmd.reload.warning3=You also might need to reconnect for some settings to take effect.
+cmd.reload.warning4=Replay Chat Bot will not be hard reloaded due to technical limitations!
+cmd.reload.finished=Reloaded Settings!
+cmd.reload.desc=Reloads MCC settings.
 
 # Respawn
 cmd.respawn.desc=Use this to respawn if you are dead.

--- a/MinecraftClient/Scripting/ChatBot.cs
+++ b/MinecraftClient/Scripting/ChatBot.cs
@@ -102,6 +102,11 @@ namespace MinecraftClient
         public virtual void Initialize() { }
 
         /// <summary>
+        /// This method is called when the bot is being unloaded, you can use it to free up resources like DB connections
+        /// </summary>
+        public virtual void OnUnload() { }
+
+        /// <summary>
         /// Called after the server has been joined successfully and chat messages are able to be sent.
         /// This method is called again after reconnecting to the server, whereas Initialize() is called only once.
         ///

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -1156,6 +1156,17 @@ namespace MinecraftClient
                             case "login": result.Append(Login); break;
                             case "serverip": result.Append(ServerIP); break;
                             case "serverport": result.Append(ServerPort); break;
+                            case "datetime":
+                                DateTime time = DateTime.Now;
+                                result.Append(String.Format("{0}-{1}-{2} {3}:{4}:{5}",
+                                    time.Year.ToString("0000"),
+                                    time.Month.ToString("00"),
+                                    time.Day.ToString("00"),
+                                    time.Hour.ToString("00"),
+                                    time.Minute.ToString("00"),
+                                    time.Second.ToString("00")));
+
+                                break;
                             default:
                                 if (localVars != null && localVars.ContainsKey(varname_lower))
                                 {

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -10,6 +10,8 @@ using MinecraftClient.Mapping;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using MinecraftClient.ChatBots;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MinecraftClient
 {
@@ -256,7 +258,7 @@ namespace MinecraftClient
         private static string ServerAliasTemp = null;
 
         //Mapping for settings sections in the INI file
-        private enum Section { Default, Main, AppVars, Proxy, MCSettings, AntiAFK, Hangman, Alerts, ChatLog, AutoRelog, ScriptScheduler, RemoteControl, ChatFormat, AutoRespond, AutoAttack, AutoFishing, AutoEat, AutoCraft, AutoDrop, Mailer, ReplayMod, FollowPlayer, Logging, Signature };
+        private enum Section { Default, Main, AppVars, Proxy, MCSettings, AntiAFK, Hangman, Alerts, ChatLog, AutoRelog, ScriptScheduler, RemoteControl, ChatFormat, AutoRespond, AutoAttack, AutoFishing, AutoEat, AutoCraft, AutoDrop, Mailer, ReplayMod, FollowPlayer, PlayerListLogger, Logging, Signature };
 
         /// <summary>
         /// Get settings section from name
@@ -852,6 +854,14 @@ namespace MinecraftClient
                         case "enabled": FollowPlayer_Enabled = str2bool(argValue); return true;
                         case "update_limit": FollowPlayer_UpdateLimit = str2int(argValue); return true;
                         case "stop_at_distance": FollowPlayer_StopAtDistance = str2int(argValue); return true;
+                    }
+                    break;
+                case Section.PlayerListLogger:
+                    switch (ToLowerIfNeed(argName))
+                    {
+                        case "enabled": PlayerLog_Enabled = str2bool(argValue); return true;
+                        case "log_file": PlayerLog_File = argValue; return true;
+                        case "log_delay": PlayerLog_Delay = str2int(argValue); return true;
                     }
                     break;
             }


### PR DESCRIPTION
This is a new PR for #2167, the reason for a new PR is that I do not want to deal with all the merge conflicts, since the version of the code I've worked in is quite outdated.

`/reload` is now only hard reload, no more soft reload (It unloads all Chat Bots and loads them back in by default).
Other command are unchanged.
All Chat Bots are now back to their original state.
Tested everything except Mailer and it works, I assume that Mailer Will work too, I do not see a reason for it not to work.

The PR is ready for merge as far as I am considered, going to leave it a bit for potential feedback.