### PR TITLE
Update builds to be self-contained

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -7,7 +7,7 @@ on:
 env:
   PROJECT: "MinecraftClient"
   target-version: "net6.0"
-  compile-flags: "--no-self-contained -c Release -p:UseAppHost=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None"
+  compile-flags: "--self-contained=true -c Release -p:UseAppHost=true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None"
 
 jobs:
   build:


### PR DESCRIPTION
Currently, we are using the `framework-dependent` method of building our binaries. This means that the user has to install .NET 6 before they are able to use the app but has the added benefit of reducing the final binary's file size.

Making a self-contained app would help reduce friction with previous users that are used to just running the executable without anything to install, as opposed to having to install .NET 6.0 on their system. 

(The previous version was running on .NET Framework, and .NET Framework is pre-installed on all Windows installs starting with Windows 7, so no additional installation is required (except when updating to a newer version of the framework.))

This comes with the unfortunate downside of massively increasing the file size (as we are also bundling .NET alongside our app.)

We would need to move our compression from `.zip` to `.7z` (which is also widely supported by various compression tools (being an open format) and gives us better compression) to reduce the download size.

For reference, the size of the binaries that we currently provide are (using build 20220928-75 as the baseline):

| Binary type | Build type | File size |
| ------------- | ------------- | ------------- | 
| MinecraftClient.exe | framework-dependent binary | 27.9mb |
| MinecraftClient-windows.zip | framework-dependent zipped | 8.5mb |
| **MinecraftClient-windows.7z** | **framework-dependent 7zipped** | **5.8mb** |
| MinecraftClient.exe | self-contained binary | 90.2mb |
| MinecraftClient-windows.zip | self-contained zipped | 35.7mb |
| **MinecraftClient-windows.7z** | **self-contained 7zipped** | **26.4mb** |

Should we continue providing the binary in `zip` format or should we move to `7z`?
The additional space savings using 7z may not be worth it if the user has to install a decompression tool.

More than likely, on users' desktops, they already have a decompression tool that supports 7z (WinRAR, 7zip, PeaZip, etc), but on servers (VPSes, Virtual Machines, Docker, etc.) they more than likely have to install a separate tool.