### PR TITLE
Update build actions to skip documentation updates

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'README') }}
 
     steps:
     - name: Setup Project Path


### PR DESCRIPTION
This adds a line to the build script that will not build commits with `README` on the title.

Additionally, add `[skip ci]` or `[ci skip]` for future commits that you don't want to build a binary with, for minor changes for example. `README` is still skipped, so it's not necessary to add them there.