### PR TITLE
Fixed Map Chat Bot sending images to Discord when just connecting.

### DIFF
--- a/MinecraftClient/ChatBots/DiscordBridge.cs
+++ b/MinecraftClient/ChatBots/DiscordBridge.cs
@@ -14,6 +14,7 @@ namespace MinecraftClient.ChatBots
     public class DiscordBridge : ChatBot
     {
         private static DiscordBridge? instance = null;
+        public bool IsConnected { get; private set; }
 
         private DiscordClient? _client;
         private DiscordChannel? _channel;
@@ -80,6 +81,7 @@ namespace MinecraftClient.ChatBots
                     }).Wait();
 
                 _client.DisconnectAsync().Wait();
+                IsConnected = false;
             }
         }
 
@@ -280,6 +282,7 @@ namespace MinecraftClient.ChatBots
                     Color = new DiscordColor(0x00FF00)
                 });
 
+                IsConnected = true;
                 await Task.Delay(-1);
             }
             catch (Exception e)


### PR DESCRIPTION
Fixed Map Chat Bot not sending maps in case the Discord Bridge was not ready and connected.
Now images are queued up for sending until the Discord Bridge bot is ready and connected.