### PR TITLE
Another bug fix and added safeguards to the Discord Bridge chat bot.

### DIFF
--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -622,6 +622,7 @@ bot.DiscordBridge.missing_token=Please provide a valid token!
 bot.DiscordBridge.guild_not_found=The provided guild/server with an id '{0}' has not been found!
 bot.DiscordBridge.channel_not_found=The provided channel with an id '{0}' has not been found!
 bot.DiscordBridge.unknown_error=An unknown error has occured!
+bot.DiscordBridge.canceled_sending=Sending message to Discord was canceled due an error occuring. For more info enable Debug.
 bot.DiscordBridge.desc=This command allows you to specify in the which direction the messages will be relayed via the Discord Bridge chat bot.
 bot.DiscordBridge.invalid_direction=Invalid direction provided! Avaliable directions: both|b, minecraft|mc, discord|dsc. Example: "dscbridge direction mc"
 bot.DiscordBridge.direction=Direction of the Discord Brdige has been switched to '{0}'!
@@ -960,6 +961,7 @@ config.ChatBot.DiscordBridge.Token=Your Discord Bot token.
 config.ChatBot.DiscordBridge.GuildId=The ID of a server/guild where you have invited the bot to.
 config.ChatBot.DiscordBridge.ChannelId=The ID of a channel where you want to interact with the MCC using the bot.
 config.ChatBot.DiscordBridge.OwnersIds=A list of IDs of people you want to be able to interact with the MCC using the bot.
+config.ChatBot.DiscordBridge.MessageSendTimeout=How long to wait (in seconds) if a message can not be sent to discord before canceling the task (minimum 1 second).
 config.ChatBot.DiscordBridge.Formats=Message formats\n# Words wrapped with { and } are going to be replaced during the code execution, do not change them!\n# For example. {message} is going to be replace with an actual message, {username} will be replaced with an username, {timestamp} with the current time.\n# For Discord message formatting, check the following: https://bit.ly/3F8CUCm
 
 # ChatBot.Farmer


### PR DESCRIPTION
Added try catch clauses and message timeout setting.
This should prevent crashing when the DiscordSharp cancels the task while sending a message.
Exceptions are reported in the Debug channel.