### PR TITLE
Added a Telegram Bridge chat bot.

### DIFF
--- a/MinecraftClient/ChatBots/TelegramBridge.cs
+++ b/MinecraftClient/ChatBots/TelegramBridge.cs
@@ -1,0 +1,291 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Telegram.Bot;
+using Telegram.Bot.Exceptions;
+using Telegram.Bot.Polling;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Tomlet.Attributes;
+
+namespace MinecraftClient.ChatBots
+{
+    public class TelegramBridge : ChatBot
+    {
+        private enum BridgeDirection
+        {
+            Both = 0,
+            Minecraft,
+            Telegram
+        }
+
+        private static TelegramBridge? instance = null;
+        public bool IsConnected { get; private set; }
+
+        private TelegramBotClient? botClient;
+        private CancellationTokenSource? cancellationToken;
+        private BridgeDirection bridgeDirection = BridgeDirection.Both;
+
+        public static Configs Config = new();
+
+        [TomlDoNotInlineObject]
+        public class Configs
+        {
+            [NonSerialized]
+            private const string BotName = "TelegramBridge";
+
+            public bool Enabled = false;
+
+            [TomlInlineComment("$config.ChatBot.TelegramBridge.Token$")]
+            public string Token = "your bot token here";
+
+            [TomlInlineComment("$config.ChatBot.TelegramBridge.ChannelId$")]
+            public string ChannelId = "";
+
+            [TomlInlineComment("$config.ChatBot.TelegramBridge.MessageSendTimeout$")]
+            public int Message_Send_Timeout = 3;
+
+            [TomlPrecedingComment("$config.ChatBot.TelegramBridge.Formats$")]
+            public string PrivateMessageFormat = "**[Private Message]** {username}: {message}";
+            public string PublicMessageFormat = "{username}: {message}";
+            public string TeleportRequestMessageFormat = "A new Teleport Request from **{username}**!";
+
+            public void OnSettingUpdate()
+            {
+                Message_Send_Timeout = Message_Send_Timeout <= 0 ? 3 : Message_Send_Timeout;
+            }
+        }
+
+        public TelegramBridge()
+        {
+            instance = this;
+        }
+
+        public override void Initialize()
+        {
+            RegisterChatBotCommand("tgbridge", "bot.TelegramBridge.desc", "tgbridge direction <both|mc|telegram>", OnTgCommand);
+
+            Task.Run(async () => await MainAsync());
+        }
+
+        ~TelegramBridge()
+        {
+            Disconnect();
+        }
+
+        public override void OnUnload()
+        {
+            Disconnect();
+        }
+
+        private void Disconnect()
+        {
+            if (botClient != null)
+            {
+                try
+                {
+                    SendMessage(Translations.TryGet("bot.TelegramBridge.disconnected"));
+                    cancellationToken?.Cancel();
+                    botClient = null;
+                }
+                catch (Exception e)
+                {
+                    LogToConsole("§w§l§f" + Translations.TryGet("bot.TelegramBridge.canceled_sending"));
+                    LogDebugToConsole(e);
+                }
+
+                IsConnected = false;
+            }
+        }
+
+        public static TelegramBridge? GetInstance()
+        {
+            return instance;
+        }
+
+        private string OnTgCommand(string cmd, string[] args)
+        {
+            if (args.Length == 2)
+            {
+                if (args[0].ToLower().Equals("direction"))
+                {
+                    string direction = args[1].ToLower().Trim();
+
+                    string? bridgeName = "";
+
+                    switch (direction)
+                    {
+                        case "b":
+                        case "both":
+                            bridgeName = "bot.TelegramBridge.direction.both";
+                            bridgeDirection = BridgeDirection.Both;
+                            break;
+
+                        case "mc":
+                        case "minecraft":
+                            bridgeName = "bot.TelegramBridge.direction.minecraft";
+                            bridgeDirection = BridgeDirection.Minecraft;
+                            break;
+
+                        case "t":
+                        case "tg":
+                        case "telegram":
+                            bridgeName = "bot.TelegramBridge.direction.discord";
+                            bridgeDirection = BridgeDirection.Telegram;
+                            break;
+
+                        default:
+                            return Translations.TryGet("bot.TelegramBridge.invalid_direction");
+                    }
+
+                    return Translations.TryGet("bot.TelegramBridge.direction", Translations.TryGet(bridgeName));
+                };
+            }
+
+            return "dscbridge direction <both|mc|discord>";
+        }
+
+        public override void GetText(string text)
+        {
+            if (!CanSendMessages())
+                return;
+
+            text = GetVerbatim(text).Trim();
+
+            // Stop the crash when an empty text is recived somehow
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            string message = "";
+            string username = "";
+
+            if (IsPrivateMessage(text, ref message, ref username))
+                message = Config.PrivateMessageFormat.Replace("{username}", username).Replace("{message}", message).Replace("{timestamp}", GetTimestamp()).Trim();
+            else if (IsChatMessage(text, ref message, ref username))
+                message = Config.PublicMessageFormat.Replace("{username}", username).Replace("{message}", message).Replace("{timestamp}", GetTimestamp()).Trim();
+            else if (IsTeleportRequest(text, ref username))
+                message = Config.TeleportRequestMessageFormat.Replace("{username}", username).Replace("{timestamp}", GetTimestamp()).Trim();
+
+            else message = text;
+
+            SendMessage(message);
+        }
+
+        public void SendMessage(string message)
+        {
+            if (!CanSendMessages() || string.IsNullOrEmpty(message))
+                return;
+
+            try
+            {
+                botClient!.SendTextMessageAsync(Config.ChannelId.Trim(), message).Wait(Config.Message_Send_Timeout);
+            }
+            catch (Exception e)
+            {
+                LogToConsole("§w§l§f" + Translations.TryGet("bot.TelegramBridge.canceled_sending"));
+                LogDebugToConsole(e);
+            }
+        }
+
+        private bool CanSendMessages()
+        {
+            return botClient != null && !string.IsNullOrEmpty(Config.ChannelId.Trim()) && bridgeDirection != BridgeDirection.Minecraft;
+        }
+
+        async Task MainAsync()
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(Config.Token.Trim()))
+                {
+                    LogToConsole(Translations.TryGet("bot.TelegramBridge.missing_token"));
+                    UnloadBot();
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(Config.ChannelId.Trim()))
+                    LogToConsole("§x§l§4" + Translations.TryGet("bot.TelegramBridge.missing_channel_id"));
+
+                botClient = new TelegramBotClient(Config.Token.Trim());
+                cancellationToken = new CancellationTokenSource();
+
+                botClient.StartReceiving(
+                    updateHandler: HandleUpdateAsync,
+                    pollingErrorHandler: HandlePollingErrorAsync,
+                    receiverOptions: new ReceiverOptions
+                    {
+                        // receive all update types
+                        AllowedUpdates = Array.Empty<UpdateType>()
+                    },
+                    cancellationToken: cancellationToken.Token
+                );
+
+                var me = await botClient.GetMeAsync();
+                IsConnected = true;
+
+                SendMessage(Translations.TryGet("bot.TelegramBridge.connected"));
+                LogToConsole("§y§l§f" + Translations.TryGet("bot.TelegramBridge.connected", me.Username));
+                await Task.Delay(-1);
+            }
+            catch (Exception e)
+            {
+                LogToConsole("§w§l§f" + Translations.TryGet("bot.TelegramBridge.unknown_error"));
+                LogToConsole(e);
+                return;
+            }
+        }
+
+        private async Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, CancellationToken _cancellationToken)
+        {
+            // Only process Message updates: https://core.telegram.org/bots/api#message
+            if (update.Message is not { } message)
+                return;
+
+            // Only process text messages
+            if (message.Text is not { } messageText)
+                return;
+
+            var chatId = message.Chat.Id;
+            var text = message.Text;
+
+            if (string.IsNullOrEmpty(text) || string.IsNullOrWhiteSpace(text))
+                return;
+
+            if (text.ToLower().Contains("/start"))
+                return;
+
+            LogDebugToConsole($"Received a '{messageText}' message in chat {chatId}.");
+
+            if (bridgeDirection == BridgeDirection.Telegram)
+            {
+                if (!text.StartsWith(".dscbridge"))
+                    return;
+            }
+
+            if (text.StartsWith("."))
+            {
+                var command = text[1..];
+
+                string? result = "";
+                PerformInternalCommand(command, ref result);
+                result = string.IsNullOrEmpty(result) ? "-" : result;
+
+                await botClient.SendTextMessageAsync(chatId: chatId, replyToMessageId: message.MessageId, text: $"{Translations.TryGet("bot.TelegramBridge.command_executed")}:\n\n{result}", cancellationToken: _cancellationToken);
+            }
+            else SendText(text);
+        }
+
+        private Task HandlePollingErrorAsync(ITelegramBotClient botClient, Exception exception, CancellationToken _cancellationToken)
+        {
+            var ErrorMessage = exception switch
+            {
+                ApiRequestException apiRequestException
+                    => $"Telegram API Error:\n[{apiRequestException.ErrorCode}]\n{apiRequestException.Message}",
+                _ => exception.ToString()
+            };
+
+            LogToConsole("§w§l§f" + ErrorMessage);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -274,6 +274,7 @@ namespace MinecraftClient
             if (Config.ChatBot.RemoteControl.Enabled) { BotLoad(new RemoteControl()); }
             if (Config.ChatBot.ReplayCapture.Enabled && reload) { BotLoad(new ReplayCapture()); }
             if (Config.ChatBot.ScriptScheduler.Enabled) { BotLoad(new ScriptScheduler()); }
+            if (Config.ChatBot.TelegramBridge.Enabled) { BotLoad(new TelegramBridge()); }
             //Add your ChatBot here by uncommenting and adapting
             //BotLoad(new ChatBots.YourBot());
         }

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -47,6 +47,7 @@
 		<NoWarn>NU1701</NoWarn>
 	</PackageReference>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+    <PackageReference Include="Telegram.Bot" Version="18.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="config\ChatBots\AutoLook.cs" />

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -624,7 +624,7 @@ bot.DiscordBridge.channel_not_found=The provided channel with an id '{0}' has no
 bot.DiscordBridge.unknown_error=An unknown error has occured!
 bot.DiscordBridge.canceled_sending=Sending message to Discord was canceled due an error occuring. For more info enable Debug.
 bot.DiscordBridge.desc=This command allows you to specify in the which direction the messages will be relayed via the Discord Bridge chat bot.
-bot.DiscordBridge.invalid_direction=Invalid direction provided! Avaliable directions: both|b, minecraft|mc, discord|dsc. Example: "dscbridge direction mc"
+bot.DiscordBridge.invalid_direction=Invalid direction provided! Available directions: both|b, minecraft|mc, discord|dsc. Example: "dscbridge direction mc"
 bot.DiscordBridge.direction=Direction of the Discord Brdige has been switched to '{0}'!
 bot.DiscordBridge.direction.both=Both
 bot.DiscordBridge.direction.minecraft=Minecraft
@@ -750,6 +750,21 @@ bot.scriptScheduler.running_time=Time / Running action: {0}
 bot.scriptScheduler.running_inverval=Interval / Running action: {0}
 bot.scriptScheduler.running_login=Login / Running action: {0}
 bot.scriptScheduler.task=triggeronfirstlogin: {0}\n triggeronlogin: {1}\n triggerontime: {2}\n triggeroninterval: {3}\n timevalue: {4}\n timeinterval: {5}\n action: {6}
+
+# TelegramBridge
+botname.TelegramBridge=TelegramBridge
+bot.TelegramBridge.command_executed=The command was executed with the result
+bot.TelegramBridge.connected=Succesfully connected with MCC!
+bot.TelegramBridge.missing_token=Please provide a valid bot token!
+bot.TelegramBridge.missing_channel_id=[WARNING] You have not provided a Channel ID, you will ONLY get replies to commands sent from Telegram!
+bot.TelegramBridge.unknown_error=An unknown error has occured!
+bot.TelegramBridge.canceled_sending=Sending message to Telegram was canceled due an error occuring. For more info enable Debug.
+bot.TelegramBridge.desc=This command allows you to specify in the which direction the messages will be relayed via the Telegram Bridge chat bot.
+bot.TelegramBridge.invalid_direction=Invalid direction provided! Available directions: both|b, minecraft|mc, telegram|tg|t. Example: "tgbridge direction mc"
+bot.TelegramBridge.direction=Direction of the Telegram Brdige has been switched to '{0}'!
+bot.TelegramBridge.direction.both=Both
+bot.TelegramBridge.direction.minecraft=Minecraft
+bot.TelegramBridge.direction.Telegram=Telegram
 
 # TestBot
 botname.TestBot=TestBot
@@ -1003,3 +1018,10 @@ config.ChatBot.ReplayCapture.Backup_Interval=How long should replay file be auto
 
 # ChatBot.ScriptScheduler
 config.ChatBot.ScriptScheduler=Schedule commands and scripts to launch on various events such as server join, date/time or time interval\n# See https://mccteam.github.io/guide/chat-bots.html#script-scheduler for more info
+
+# ChatBot.TelegramBridge
+config.ChatBot.TelegramBridge=This bot allows you to send and receive messages and commands via a Telegram Bot DM or to receive messages in a Telegram channel.\n# /!\ NOTE: You can't send messages and commands from a group channel, you can only send them in the bot DM, but you can get the messages from the client in a group channel.\n#-----------------------------------------------------------\n# Setup:\n# First you need to create a Telegram bot and obtain an API key, to do so, go to Telegram and find @botfather\n# Click on "Start" button and read the bot reply, then type "/newbot", the Botfather will guide you through the bot creation.\n# Once you create the bot, copy the API key that you have gotten, and put it into the "Token" field of "ChatBot.TelegramBridge" section (this section).\n# /!\ Do not share this token with anyone else as it will give them the control over your bot. Save it securely.\n# Set the "Enabled" field to true (in this section), then enable "DebugMessages" by setting it to true, in the "Logging" section and save the file.\n# Then launch the client and go to Telegram, find your newly created bot by searching for it with its username, and open a DM with it.\n# Click on "Start" button and type and send any message to the bot, then in the client console you should see something like: "[MCC] [TelegramBridge] Received a 'e' message in chat 2127848600."\n# Copy the chat number (eg. 2127848600) and paste it in the "ChannelId" field (in this section), disable "DebugMessages" if you want and save the file.\n# Now you can use the bot using it's DM.\n#-----------------------------------------------------------\n# NOTE: If you want to recieve messages to a group channel instead, make the channel temporarely public, invite the bot to it and make it an administrator, then set the channel to private if you want.\n# Then set the "ChannelId" field to the @ of your channel (you must include the @ in the settings, eg. "@mysupersecretchannel"), this is the username you can see in the invite link of the channel.\n# /!\ Only include the username with @ prefix, do not include the rest of the link. Example if you have "https://t.me/mysupersecretchannel", the "ChannelId" will be "@mysupersecretchannel".\n# /!\ Note that you will not be able to send messages to the client from a group channel!\n#-----------------------------------------------------------\n# How to use the bot:\n# To execute an MCC command, prefix it with a dot ".", example: ".move 143 64 735" .\n# To send a message, simply type it out and hit enter.
+config.ChatBot.TelegramBridge.Token=Your Telegram Bot token.
+config.ChatBot.TelegramBridge.ChannelId=The ID of a channel where you want to interact with the MCC using the bot.
+config.ChatBot.TelegramBridge.MessageSendTimeout=How long to wait (in seconds) if a message can not be sent to Telegram before canceling the task (minimum 1 second).
+config.ChatBot.TelegramBridge.Formats=Message formats\n# Words wrapped with { and } are going to be replaced during the code execution, do not change them!\n# For example. {message} is going to be replace with an actual message, {username} will be replaced with an username, {timestamp} with the current time.\n# For Telegram message formatting, check the following: https://sendpulse.com/blog/telegram-text-formatting

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -1163,6 +1163,13 @@ namespace MinecraftClient
                     get { return ChatBots.ScriptScheduler.Config; }
                     set { ChatBots.ScriptScheduler.Config = value; ChatBots.ScriptScheduler.Config.OnSettingUpdate(); }
                 }
+
+                [TomlPrecedingComment("$config.ChatBot.TelegramBridge$")]
+                public ChatBots.TelegramBridge.Configs TelegramBridge
+                {
+                    get { return ChatBots.TelegramBridge.Config; }
+                    set { ChatBots.TelegramBridge.Config = value; ChatBots.TelegramBridge.Config.OnSettingUpdate(); }
+                }
             }
         }
 


### PR DESCRIPTION
Basically same as Discord Bridge chat bot, but for Telegram.

TODO: 
- Enable Map chat bot to use the Telegram Bridge chat bot to send maps to Telegram.
- Figure out a way to limit who can use the bot (aka. some simple authentication)