### PR TITLE
SetExperience: Revert 1.19.3 fields swap

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -1955,18 +1955,8 @@ namespace MinecraftClient.Protocol.Handlers
                         case PacketTypesIn.SetExperience:
                             float experiencebar = dataTypes.ReadNextFloat(packetData);
                             int totalexperience, level;
-
-                            if (protocolVersion >= MC_1_19_3_Version)
-                            {
-                                totalexperience = dataTypes.ReadNextVarInt(packetData);
-                                level = dataTypes.ReadNextVarInt(packetData);
-                            }
-                            else
-                            {
-                                level = dataTypes.ReadNextVarInt(packetData);
-                                totalexperience = dataTypes.ReadNextVarInt(packetData);
-                            }
-
+                            level = dataTypes.ReadNextVarInt(packetData);
+                            totalexperience = dataTypes.ReadNextVarInt(packetData);
                             handler.OnSetExperience(experiencebar, level, totalexperience);
                             break;
                         case PacketTypesIn.Explosion:


### PR DESCRIPTION
Seems like the fields are not swapped when testing in 1.19.3 vanilla/paper server

Fix #2429 