### PR TITLE
Fix fetching translations for github actions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-build
     # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
-    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' }}
+    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' || github.repository == 'breadbyte' }}
     timeout-minutes: 15
   
     steps:   

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() && needs.fetch-translation.result != 'failure' }}
     needs: [determine-build, fetch-translations]
     timeout-minutes: 15
     strategy:
@@ -95,13 +95,6 @@ jobs:
         lookup-only: true
         restore-keys: "translation-"
   
-    - name: Checkout
-      uses: actions/checkout@v3
-      if: steps.cache-check.outputs.cache-hit != 'true'
-      with:
-        fetch-depth: 0
-        submodules: 'true'
-  
     - name: Download translations from crowdin
       uses: crowdin/github-action@v1.6.0
       if: steps.cache-check.outputs.cache-hit != 'true'
@@ -129,7 +122,7 @@ jobs:
         
   build-transition-version:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() && needs.fetch-translation.result != 'failure' }}
     needs: [determine-build, fetch-translations]
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.fetch-translation.result != 'failure' }}
+    if: ${{ always() && needs.fetch-translations.result != 'failure' }}
     needs: [determine-build, fetch-translations]
     timeout-minutes: 15
     strategy:
@@ -122,7 +122,7 @@ jobs:
         
   build-transition-version:
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.fetch-translation.result != 'failure' }}
+    if: ${{ always() && needs.fetch-translations.result != 'failure' }}
     needs: [determine-build, fetch-translations]
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: ${{ jobs.fetch-translations.result == 'skipped' }}
+      if: ${{ always() && needs.fetch-translations.result == 'skipped' }}
       with:
         fetch-depth: 0
         submodules: 'true'
@@ -123,7 +123,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: ${{ jobs.fetch-translations.result == 'skipped' }}
+      if: ${{ always() && needs.fetch-translations.result == 'skipped' }}
       with:
         fetch-depth: 0
         submodules: 'true'

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-build
     # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
-    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' || github.repository == 'breadbytes/Minecraft-Console-Client' }}
+    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' || github.repository == 'breadbyte/Minecraft-Console-Client' }}
     timeout-minutes: 15
   
     steps:   

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-build
     # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
-    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' || github.repository == 'breadbyte/Minecraft-Console-Client' }}
+    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' }}
     timeout-minutes: 15
   
     steps:   

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      if: ${{ jobs.fetch-translations.result == 'skipped' }}
       with:
         fetch-depth: 0
         submodules: 'true'
@@ -80,7 +81,7 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-latest
     needs: determine-build
-    # Only works in MCCTeam repository, since it needs crowdin secrets.
+    # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
     if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' }}
     timeout-minutes: 15
   
@@ -96,7 +97,7 @@ jobs:
       uses: crowdin/github-action@v1.6.0
       if: steps.cache-check.outputs.cache-hit != 'true'
       with:
-        upload_sources: true
+        upload_sources: false
         upload_translations: false
         download_translations: true
 
@@ -112,7 +113,6 @@ jobs:
         
   build-transition-version:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
     needs: [determine-build, fetch-translations]
     timeout-minutes: 15
     strategy:
@@ -123,6 +123,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      if: ${{ jobs.fetch-translations.result == 'skipped' }}
       with:
         fetch-depth: 0
         submodules: 'true'
@@ -175,7 +176,6 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         mode: uploadReleaseAsset
         filePath: ${{ env.target-out-path }}/mcc-${{ matrix.target }}.zip
-        # ${{ env.PROJECT }}-linux.zip
         assetName: ${{ env.PROJECT }}-${{ (contains(matrix.target, 'linux-x64') && 'linux.zip') || (contains(matrix.target, 'win-x86') && 'windows-x86.zip') || (contains(matrix.target, 'win-x64') && 'windows-x64.zip') || (contains(matrix.target, 'linux-arm64') && 'linux-arm64.zip') || (contains(matrix.target, 'osx-x64') && 'osx.zip') }}
         tag: ${{ format('{0}-{1}', env.date, github.run_number) }}
         

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-build
     # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
-    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' || github.repository == 'breadbyte' }}
+    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' || github.repository == 'breadbyte/Minecraft-Console-Client' }}
     timeout-minutes: 15
   
     steps:   

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -86,12 +86,21 @@ jobs:
     timeout-minutes: 15
   
     steps:   
-    - name: Cache
-      uses: actions/cache@v3.2.4
+    - name: Check cache
+      uses: actions/cache/restore@v3
       id: cache-check
       with:
         path: ${{ github.workspace }}/*
-        key: 'translation-${{ github.sha }}'
+        key: "translation-${{ github.sha }}"
+        lookup-only: true
+        restore-keys: "translation-"
+  
+    - name: Checkout
+      uses: actions/checkout@v3
+      if: steps.cache-check.outputs.cache-hit != 'true'
+      with:
+        fetch-depth: 0
+        submodules: 'true'
   
     - name: Download translations from crowdin
       uses: crowdin/github-action@v1.6.0
@@ -110,6 +119,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
         CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
+      
+    - name: Save cache
+      uses: actions/cache/save@v3
+      if: steps.cache-check.outputs.cache-hit != 'true'
+      with:
+        path:  ${{ github.workspace }}/*
+        key: "translation-${{ github.sha }}"
         
   build-transition-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,9 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-build
     # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
-    if: |
-      github.repository == 'MCCTeam/Minecraft-Console-Client'
-      github.repository == 'breadbytes/Minecraft-Console-Client'
+    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' || github.repository == 'breadbytes/Minecraft-Console-Client' }}
     timeout-minutes: 15
   
     steps:   

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -95,6 +95,13 @@ jobs:
         lookup-only: true
         restore-keys: "translation-"
   
+    - name: Checkout
+      uses: actions/checkout@v3
+      if: steps.cache-check.outputs.cache-hit != 'true'
+      with:
+        fetch-depth: 0
+        submodules: 'true'
+
     - name: Download translations from crowdin
       uses: crowdin/github-action@v1.6.0
       if: steps.cache-check.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -82,7 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-build
     # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
-    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' }}
+    if: |
+      github.repository == 'MCCTeam/Minecraft-Console-Client'
+      github.repository == 'breadbytes/Minecraft-Console-Client'
     timeout-minutes: 15
   
     steps:   
@@ -113,6 +115,7 @@ jobs:
         
   build-transition-version:
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     needs: [determine-build, fetch-translations]
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
As reported in #2424.

This PR makes the following changes:
1. Actually makes the entire build fail when fetching translations fails, but continues building if it is skipped. This was broken in #2424.

The translation cache is actually a _crucial_ part of the system, as fetching the translations per build in parallel is _not allowed_ by the Crowdin API, and returns an error.

2. Fetching the translations also fetches the repository, so we skip checking out the repository if fetching the translations was successful.