### PR TITLE
FollowPlayer: Improve player detection

### DIFF
--- a/MinecraftClient/ChatBots/FollowPlayer.cs
+++ b/MinecraftClient/ChatBots/FollowPlayer.cs
@@ -151,12 +151,6 @@ namespace MinecraftClient.ChatBots
 
         public override void OnEntityMove(Entity entity)
         {
-
-            if (_updateCounter < Settings.DoubleToTick(Config.Update_Limit))
-                return;
-
-            _updateCounter = 0;
-
             if (entity.Type != EntityType.Player)
                 return;
 
@@ -165,6 +159,11 @@ namespace MinecraftClient.ChatBots
 
             if (_playerToFollow != entity.Name.ToLower())
                 return;
+
+            if (_updateCounter < Settings.DoubleToTick(Config.Update_Limit))
+                return;
+
+            _updateCounter = 0;
 
             if (!CanMoveThere(entity.Location))
                 return;


### PR DESCRIPTION
Putting limit counter at the topmost will cause it to miss many target player movement event. In my case it receive zero and doesn't move at all.

We should first filter out target player movement event before applying the limit counter so that the bot always receive target player movement.