### PR TITLE
Partially fixed interaction with Armor Stand

### DIFF
--- a/MinecraftClient/Commands/Entitycmd.cs
+++ b/MinecraftClient/Commands/Entitycmd.cs
@@ -314,7 +314,11 @@ namespace MinecraftClient.Commands
                     handler.InteractEntity(entity.ID, InteractType.Attack);
                     return Translations.cmd_entityCmd_attacked;
                 case ActionType.Use:
-                    handler.InteractEntity(entity.ID, InteractType.Interact);
+                    bool shouldInteractAt = entity.Type == EntityType.ArmorStand ||
+                                            entity.Type == EntityType.ChestMinecart ||
+                                            entity.Type == EntityType.ChestBoat;
+                    
+                    handler.InteractEntity(entity.ID, shouldInteractAt ? InteractType.InteractAt : InteractType.Interact);
                     return Translations.cmd_entityCmd_used;
                 case ActionType.List:
                     return GetEntityInfoDetailed(handler, entity);

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -2195,16 +2195,26 @@ namespace MinecraftClient
 
             if (entities.ContainsKey(entityID))
             {
-                if (type == InteractType.Interact)
+                switch (type)
                 {
-                    return handler.SendInteractEntity(entityID, (int)type, (int)hand);
-                }
-                else
-                {
-                    return handler.SendInteractEntity(entityID, (int)type);
+                    case InteractType.Interact:
+                        return handler.SendInteractEntity(entityID, (int)type, (int)hand);
+                    
+                    case InteractType.InteractAt:
+                        return handler.SendInteractEntity(
+                            EntityID: entityID, 
+                            type: (int)type, 
+                            X: (float)entities[entityID].Location.X, 
+                            Y: (float)entities[entityID].Location.Y, 
+                            Z: (float)entities[entityID].Location.Z, 
+                            hand: (int)hand);
+                    
+                    default:
+                        return handler.SendInteractEntity(entityID, (int)type);
                 }
             }
-            else return false;
+            
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Partially fixed interaction with Armor Stand
There is a problem, the bot is able to put equipment on, but it only can take back the helmet, I have tried using the `/look` command to change the yaw and pitch and to try to pick up a chest plate when the bot hand was empty and it would not work.
No idea why this is happening, needs further research and testing.
Also, the attack won't work, tried sending multiple packets at the same time to test it out, it does not work, no idea why.
So maybe someone else has an idea.

https://user-images.githubusercontent.com/441903/228941588-4da31af3-05ec-47c4-81a3-b26e81c701fc.mp4
