### PR TITLE
Fixed crash on 1.8 when receiving entity data

### DIFF
--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -504,6 +504,7 @@ namespace MinecraftClient.Protocol.Handlers
 
 
             int metadata = -1;
+            bool hasData = false;
             byte entityPitch, entityYaw;
 
             if (living)
@@ -522,13 +523,16 @@ namespace MinecraftClient.Protocol.Handlers
 
                 // Data
                 if (protocolversion >= Protocol18Handler.MC_1_19_Version)
-                    ReadNextVarInt(cache);
-                else ReadNextInt(cache);
+                    hasData = ReadNextVarInt(cache) == 1;
+                else hasData = ReadNextInt(cache) == 1;
             }
 
-            short velocityX = ReadNextShort(cache);
-            short velocityY = ReadNextShort(cache);
-            short velocityZ = ReadNextShort(cache);
+            if (hasData)
+            {
+                short velocityX = ReadNextShort(cache);
+                short velocityY = ReadNextShort(cache);
+                short velocityZ = ReadNextShort(cache);
+            }
 
             return new Entity(entityID, entityType, new Location(entityX, entityY, entityZ), entityYaw, entityPitch, metadata);
         }

--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -523,15 +523,25 @@ namespace MinecraftClient.Protocol.Handlers
 
                 // Data
                 if (protocolversion >= Protocol18Handler.MC_1_19_Version)
-                    hasData = ReadNextVarInt(cache) == 1;
+                    ReadNextVarInt(cache);
                 else hasData = ReadNextInt(cache) == 1;
             }
 
-            if (hasData)
+            // In 1.8 those 3 fields for Velocity are optional
+            if (protocolversion < Protocol18Handler.MC_1_9_Version)
             {
-                short velocityX = ReadNextShort(cache);
-                short velocityY = ReadNextShort(cache);
-                short velocityZ = ReadNextShort(cache);
+                if (hasData)
+                {
+                    ReadNextShort(cache);
+                    ReadNextShort(cache);
+                    ReadNextShort(cache);
+                }
+            }
+            else
+            {
+                ReadNextShort(cache);
+                ReadNextShort(cache);
+                ReadNextShort(cache);
             }
 
             return new Entity(entityID, entityType, new Location(entityX, entityY, entityZ), entityYaw, entityPitch, metadata);


### PR DESCRIPTION
Fixed crash on 1.8 when receiving entity data
The packet optional fields for Velocity were read all the time