### PR TITLE
Fixed crashing when having an OP on 1.19.4 (DeclareCommands fix)

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Packet/s2c/DeclareCommands.cs
+++ b/MinecraftClient/Protocol/Handlers/Packet/s2c/DeclareCommands.cs
@@ -76,6 +76,11 @@ namespace MinecraftClient.Protocol.Handlers.packet.s2c
                 string? suggestionsType = ((flags & 0x10) == 0x10) ? dataTypes.ReadNextString(packetData) : null;
 
                 Nodes[i] = new(flags, childs, redirectNode, name, paser, suggestionsType);
+                
+                // Quick dirty fix to a crashreal
+                // TODO: Investigate further, see if this breaks some commands from being added to the auto completion list
+                if (name != null && name.ToLower().Equals("end"))
+                    break;
             }
             RootIdx = dataTypes.ReadNextVarInt(packetData);
 


### PR DESCRIPTION
A crash only happens if the player is an OP.
The server sends about 1300++ nodes in DeclareCommands packet.
Now, i am not sure if this is a bug with number of nodes on their side or not, because at one point they send a node with a name of `end`, after that one it crashes.
So, I've implemented a quick dirty fix that breaks out of the node reading loop, it works, but I am not sure if it prevents any more declared commands from being read.
From my quick investigation, the parsers and the packet reading code matches the wiki.
I'll not merge yet, if someone has some free time, please investigate further, I do not have more free time, neither I am that familiar with this part of the code.