### PR TITLE
Made Alert.cs TriggerByWords method case insensitive

### DIFF
--- a/MinecraftClient/ChatBots/Alerts.cs
+++ b/MinecraftClient/ChatBots/Alerts.cs
@@ -92,10 +92,10 @@ namespace MinecraftClient.ChatBots
                 text = GetVerbatim(text).ToLower();
 
                 //Proceed only if no exclusions are found in text
-                if (!Config.Excludes.Any(exclusion => text.Contains(exclusion)))
+                if (!Config.Excludes.Any(exclusion => text.Contains(exclusion.ToLower())))
                 {
                     //Show an alert for each alert item found in text, if any
-                    foreach (string alert in Config.Matches.Where(alert => text.Contains(alert)))
+                    foreach (string alert in Config.Matches.Where(alert => text.Contains(alert.ToLower())))
                     {
                         if (Config.Beep_Enabled)
                             Console.Beep(); //Text found !


### PR DESCRIPTION
Made Chatbot.Alert TriggerByWords case insensitive. until now if you placed any string that contains an **uppercase** in "Matches" or "Excludes" array, it wouldn't be detected in chat This was because chat text would go trough .ToLower() before comparing and Matches array didn't.