### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -114,7 +114,7 @@ namespace MinecraftClient
 
         /// <summary>
         /// Write a Minecraft-Like formatted string to the standard output, using §c color codes
-        /// See minecraft.gamepedia.com/Classic_server_protocol#Color_Codes for more info
+        /// <see href="https://minecraft.wiki/w/Classic_server_protocol#Color_codes"/> for more info
         /// </summary>
         /// <param name="str">String to write</param>
         /// <param name="acceptnewlines">If false, space are printed instead of newlines</param>

--- a/MinecraftClient/Mapping/CommandBlockFlags.cs
+++ b/MinecraftClient/Mapping/CommandBlockFlags.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents a unit movement in the world
     /// </summary>
-    /// <see href="http://minecraft.gamepedia.com/Coordinates"/>
+    /// <see href="https://minecraft.wiki/w/Coordinates"/>
     public enum CommandBlockFlags
     {
         TrackOutput = 0x01,

--- a/MinecraftClient/Mapping/CommandBlockMode.cs
+++ b/MinecraftClient/Mapping/CommandBlockMode.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents a unit movement in the world
     /// </summary>
-    /// <see href="http://minecraft.gamepedia.com/Coordinates"/>
+    /// <see href="https://minecraft.wiki/w/Coordinates"/>
     public enum CommandBlockMode
     {
         Sequence = 0,

--- a/MinecraftClient/Mapping/Direction.cs
+++ b/MinecraftClient/Mapping/Direction.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents a unit movement in the world
     /// </summary>
-    /// <see href="http://minecraft.gamepedia.com/Coordinates"/>
+    /// <see href="https://minecraft.wiki/w/Coordinates"/>
     public enum Direction
     {
         South = 0,

--- a/MinecraftClient/Mapping/Material2Tool.cs
+++ b/MinecraftClient/Mapping/Material2Tool.cs
@@ -5,7 +5,7 @@ namespace MinecraftClient.Mapping
 {
     public static class Material2Tool
     {
-        // Made with the following ressources: https://minecraft.fandom.com/wiki/Breaking
+        // Made with the following ressources: https://minecraft.wiki/w/Breaking
         // Sorted in alphabetical order.
         // Minable by Any Pickaxe.
         private static readonly List<Material> pickaxeTier0 = new()

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -2575,15 +2575,15 @@ namespace MinecraftClient
             switch (newSpeed)
             {
                 case MovementType.Sneak:
-                    // https://minecraft.fandom.com/wiki/Sneaking#Effects - Sneaking  1.31m/s
+                    // https://minecraft.wiki/w/Sneaking#Effects - Sneaking  1.31m/s
                     Config.Main.Advanced.MovementSpeed = 2;
                     break;
                 case MovementType.Walk:
-                    // https://minecraft.fandom.com/wiki/Walking#Usage - Walking 4.317 m/s
+                    // https://minecraft.wiki/w/Walking#Usage - Walking 4.317 m/s
                     Config.Main.Advanced.MovementSpeed = 4;
                     break;
                 case MovementType.Sprint:
-                    // https://minecraft.fandom.com/wiki/Sprinting#Usage - Sprinting 5.612 m/s
+                    // https://minecraft.wiki/w/Sprinting#Usage - Sprinting 5.612 m/s
                     Config.Main.Advanced.MovementSpeed = 5;
                     break;
             }
@@ -3340,7 +3340,7 @@ namespace MinecraftClient
 
         /// <summary>
         /// Called when an update of the map is sent by the server, take a look at https://wiki.vg/Protocol#Map_Data for more info on the fields
-        /// Map format and colors: https://minecraft.fandom.com/wiki/Map_item_format
+        /// Map format and colors: https://minecraft.wiki/w/Map_item_format
         /// </summary>
         /// <param name="mapid">Map ID of the map being modified</param>
         /// <param name="scale">A scale of the Map, from 0 for a fully zoomed-in map (1 block per pixel) to 4 for a fully zoomed-out map (16 blocks per pixel)</param>

--- a/MinecraftClient/Protocol/IMinecraftComHandler.cs
+++ b/MinecraftClient/Protocol/IMinecraftComHandler.cs
@@ -376,7 +376,7 @@ namespace MinecraftClient.Protocol
 
         /// <summary>
         /// Called when an update of the map is sent by the server, take a look at https://wiki.vg/Protocol#Map_Data for more info on the fields
-        /// Map format and colors: https://minecraft.fandom.com/wiki/Map_item_format
+        /// Map format and colors: https://minecraft.wiki/w/Map_item_format
         /// </summary>
         /// <param name="mapid">Map ID of the map being modified</param>
         /// <param name="scale">A scale of the Map, from 0 for a fully zoomed-in map (1 block per pixel) to 4 for a fully zoomed-out map (16 blocks per pixel)</param>

--- a/MinecraftClient/Scripting/ChatBot.cs
+++ b/MinecraftClient/Scripting/ChatBot.cs
@@ -271,7 +271,7 @@ namespace MinecraftClient.Scripting
 
         /// <summary>
         /// Called when an update of the map is sent by the server, take a look at https://wiki.vg/Protocol#Map_Data for more info on the fields
-        /// Map format and colors: https://minecraft.fandom.com/wiki/Map_item_format
+        /// Map format and colors: https://minecraft.wiki/w/Map_item_format
         /// </summary>
         /// <param name="mapid">Map ID of the map being modified</param>
         /// <param name="scale">A scale of the Map, from 0 for a fully zoomed-in map (1 block per pixel) to 4 for a fully zoomed-out map (16 blocks per pixel)</param>


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.