### PR TITLE
Add Yggdrasil Login

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -416,7 +416,7 @@ namespace MinecraftClient
             else
             {
                 // Validate cached session or login new session.
-                if (Config.Main.Advanced.SessionCache != CacheType.none && SessionCache.Contains(loginLower))
+                if (Config.Main.Advanced.SessionCache != CacheType.none && SessionCache.Contains(loginLower) && Config.Main.General.AccountType != LoginType.Yggdrasil)
                 {
                     session = SessionCache.Get(loginLower);
                     result = ProtocolHandler.GetTokenValidation(session);
@@ -455,7 +455,7 @@ namespace MinecraftClient
                     SessionCache.Store(loginLower, session);
 
                 if (result == ProtocolHandler.LoginResult.Success)
-                    session.SessionPreCheckTask = Task.Factory.StartNew(() => session.SessionPreCheck());
+                    session.SessionPreCheckTask = Task.Factory.StartNew(() => session.SessionPreCheck(Config.Main.General.AccountType));
             }
 
             if (result == ProtocolHandler.LoginResult.Success)

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -416,7 +416,7 @@ namespace MinecraftClient
             else
             {
                 // Validate cached session or login new session.
-                if (Config.Main.Advanced.SessionCache != CacheType.none && SessionCache.Contains(loginLower) && Config.Main.General.AccountType != LoginType.Yggdrasil)
+                if (Config.Main.Advanced.SessionCache != CacheType.none && SessionCache.Contains(loginLower) && Config.Main.General.AccountType != LoginType.yggdrasil)
                 {
                     session = SessionCache.Get(loginLower);
                     result = ProtocolHandler.GetTokenValidation(session);
@@ -447,7 +447,7 @@ namespace MinecraftClient
 
                 if (result != ProtocolHandler.LoginResult.Success)
                 {
-                    ConsoleIO.WriteLine(string.Format(Translations.mcc_connecting, Config.Main.General.AccountType == LoginType.mojang ? "Minecraft.net" : "Microsoft"));
+                    ConsoleIO.WriteLine(string.Format(Translations.mcc_connecting, Config.Main.General.AccountType == LoginType.mojang ? "Minecraft.net" : (Config.Main.General.AccountType == LoginType.microsoft ? "Microsoft" : Config.Main.General.AuthServer.Host)));
                     result = ProtocolHandler.GetLogin(InternalConfig.Account.Login, InternalConfig.Account.Password, Config.Main.General.AccountType, out session);
                 }
 
@@ -649,6 +649,7 @@ namespace MinecraftClient
                     ProtocolHandler.LoginResult.OtherError          =>  Translations.error_login_network,
                     ProtocolHandler.LoginResult.SSLError            =>  Translations.error_login_ssl,
                     ProtocolHandler.LoginResult.UserCancel          =>  Translations.error_login_cancel,
+                    ProtocolHandler.LoginResult.WrongSelection      =>  Translations.error_login_blocked,
                     _                                               =>  Translations.error_login_unknown,
 #pragma warning restore format // @formatter:on
                 };

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -538,7 +538,7 @@ namespace MinecraftClient.Protocol.Handlers
 
                 if (needCheckSession)
                 {
-                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash)) || (type == LoginType.Yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
+                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash)) || (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -15,6 +15,7 @@ using MinecraftClient.Protocol.Session;
 using MinecraftClient.Proxy;
 using MinecraftClient.Scripting;
 using static MinecraftClient.Settings;
+using static MinecraftClient.Settings.MainConfigHealper.MainConfig.GeneralConfig;
 
 namespace MinecraftClient.Protocol.Handlers
 {
@@ -504,7 +505,7 @@ namespace MinecraftClient.Protocol.Handlers
                 else if (Settings.Config.Logging.DebugMessages)
                     ConsoleIO.WriteLineFormatted("§8" + string.Format(Translations.mcc_handshake, serverID));
 
-                return StartEncryption(uuid, username, sessionID, token, serverID, PublicServerkey, session);
+                return StartEncryption(uuid, username, sessionID, Config.Main.General.AccountType, token, serverID, PublicServerkey, session);
             }
             else
             {
@@ -513,7 +514,7 @@ namespace MinecraftClient.Protocol.Handlers
             }
         }
 
-        private bool StartEncryption(string uuid, string username, string sessionID, byte[] token, string serverIDhash, byte[] serverPublicKey, SessionToken session)
+        private bool StartEncryption(string uuid, string username, string sessionID, LoginType type, byte[] token, string serverIDhash, byte[] serverPublicKey, SessionToken session)
         {
             RSACryptoServiceProvider RSAService = CryptoHandler.DecodeRSAPublicKey(serverPublicKey)!;
             byte[] secretKey = CryptoHandler.ClientAESPrivateKey ?? CryptoHandler.GenerateAESPrivateKey();
@@ -537,7 +538,7 @@ namespace MinecraftClient.Protocol.Handlers
 
                 if (needCheckSession)
                 {
-                    if (ProtocolHandler.SessionCheck(uuid, sessionID, serverHash))
+                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash)) || (type == LoginType.Yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -2614,7 +2614,7 @@ namespace MinecraftClient.Protocol.Handlers
                 {
                     string serverHash = CryptoHandler.GetServerHash(serverIDhash, serverPublicKey, secretKey);
 
-                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash) )|| (type == LoginType.Yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
+                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash) )|| (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -26,6 +26,7 @@ using MinecraftClient.Proxy;
 using MinecraftClient.Scripting;
 using Newtonsoft.Json;
 using static MinecraftClient.Settings;
+using static MinecraftClient.Settings.MainConfigHealper.MainConfig.GeneralConfig;
 
 namespace MinecraftClient.Protocol.Handlers
 {
@@ -2562,7 +2563,7 @@ namespace MinecraftClient.Protocol.Handlers
                     string serverID = dataTypes.ReadNextString(packetData);
                     byte[] serverPublicKey = dataTypes.ReadNextByteArray(packetData);
                     byte[] token = dataTypes.ReadNextByteArray(packetData);
-                    return StartEncryption(handler.GetUserUuidStr(), handler.GetSessionID(), token, serverID,
+                    return StartEncryption(handler.GetUserUuidStr(), handler.GetSessionID(), Config.Main.General.AccountType, token, serverID,
                         serverPublicKey, playerKeyPair, session);
                 }
                 else if (packetID == 0x02) //Login successful
@@ -2587,7 +2588,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// Start network encryption. Automatically called by Login() if the server requests encryption.
         /// </summary>
         /// <returns>True if encryption was successful</returns>
-        private bool StartEncryption(string uuid, string sessionID, byte[] token, string serverIDhash,
+        private bool StartEncryption(string uuid, string sessionID, LoginType type, byte[] token, string serverIDhash,
             byte[] serverPublicKey, PlayerKeyPair? playerKeyPair, SessionToken session)
         {
             RSACryptoServiceProvider RSAService = CryptoHandler.DecodeRSAPublicKey(serverPublicKey)!;
@@ -2613,7 +2614,7 @@ namespace MinecraftClient.Protocol.Handlers
                 {
                     string serverHash = CryptoHandler.GetServerHash(serverIDhash, serverPublicKey, secretKey);
 
-                    if (ProtocolHandler.SessionCheck(uuid, sessionID, serverHash))
+                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash) )|| (type == LoginType.Yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -571,20 +571,20 @@ namespace MinecraftClient.Protocol
                             }
                             else
                             {
-                                string availablePlayers = "";
+                                string availableProfiles = "";
                                 foreach (Json.JSONData profile in loginResponse.Properties["availableProfiles"].DataArray)
                                 {
-                                    availablePlayers += " " + profile.Properties["name"].StringValue;
+                                    availableProfiles += " " + profile.Properties["name"].StringValue;
                                 } 
-                                ConsoleIO.WriteLine(Translations.mcc_avaliable_players + availablePlayers);
+                                ConsoleIO.WriteLine(Translations.mcc_avaliable_profiles + availableProfiles);
 
-                                ConsoleIO.WriteLine(Translations.mcc_select_player);
-                                string selectedPlayer = ConsoleIO.ReadLine();
-                                ConsoleIO.WriteLine(Translations.mcc_selected_player + selectedPlayer);
+                                ConsoleIO.WriteLine(Translations.mcc_select_profile);
+                                string selectedProfileName = ConsoleIO.ReadLine();
+                                ConsoleIO.WriteLine(Translations.mcc_selected_profile + " " + selectedProfileName);
                                 Json.JSONData? selectedProfile = null;
                                 foreach (Json.JSONData profile in loginResponse.Properties["availableProfiles"].DataArray)
                                 {
-                                    selectedProfile = profile.Properties["name"].StringValue == selectedPlayer ? profile : selectedProfile;
+                                    selectedProfile = profile.Properties["name"].StringValue == selectedProfileName ? profile : selectedProfile;
                                 }
 
                                 if (selectedProfile != null) 

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -581,7 +581,7 @@ namespace MinecraftClient.Protocol
                                 ConsoleIO.WriteLine(Translations.mcc_select_player);
                                 string selectedPlayer = ConsoleIO.ReadLine();
                                 ConsoleIO.WriteLine(Translations.mcc_selected_player + selectedPlayer);
-                                Json.JSONData selectedProfile = null;
+                                Json.JSONData? selectedProfile = null;
                                 foreach (Json.JSONData profile in loginResponse.Properties["availableProfiles"].DataArray)
                                 {
                                     selectedProfile = profile.Properties["name"].StringValue == selectedPlayer ? profile : selectedProfile;

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -134,7 +134,7 @@ namespace MinecraftClient.Protocol
             if (Array.IndexOf(supportedVersions_Protocol16, ProtocolVersion) > -1)
                 return new Protocol16Handler(Client, ProtocolVersion, Handler);
 
-            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110, 210, 315, 316, 335, 338, 340, 393, 401, 404, 477, 480, 485, 490, 498, 573, 575, 578, 735, 736, 751, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763 };
+            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110, 210, 315, 316, 335, 338, 340, 393, 401, 404, 477, 480, 485, 490, 498, 573, 575, 578, 735, 736, 751, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763};
 
             if (Array.IndexOf(supportedVersions_Protocol18, ProtocolVersion) > -1)
                 return new Protocol18Handler(Client, ProtocolVersion, Handler, forgeInfo);
@@ -446,7 +446,11 @@ namespace MinecraftClient.Protocol
             {
                 return MojangLogin(user, pass, out session);
             }
-            else throw new InvalidOperationException("Account type must be Mojang or Microsoft");
+            else if (type == LoginType.Yggdrasil)
+            {
+                return YggdrasiLogin(user, pass, out session);
+            }
+            else throw new InvalidOperationException("Account type must be Mojang or Microsoft or valid authlib 3rd Servers!");
         }
 
         /// <summary>
@@ -464,7 +468,7 @@ namespace MinecraftClient.Protocol
             {
                 string result = "";
                 string json_request = "{\"agent\": { \"name\": \"Minecraft\", \"version\": 1 }, \"username\": \"" + JsonEncode(user) + "\", \"password\": \"" + JsonEncode(pass) + "\", \"clientToken\": \"" + JsonEncode(session.ClientID) + "\" }";
-                int code = DoHTTPSPost("authserver.mojang.com", "/authenticate", json_request, ref result);
+                int code = DoHTTPSPost("authserver.mojang.com",443, "/authenticate", json_request, ref result);
                 if (code == 200)
                 {
                     if (result.Contains("availableProfiles\":[]}"))
@@ -534,7 +538,84 @@ namespace MinecraftClient.Protocol
                 return LoginResult.OtherError;
             }
         }
+    private static LoginResult YggdrasiLogin(string user, string pass, out SessionToken session)
+        {
+            session = new SessionToken() { ClientID = Guid.NewGuid().ToString().Replace("-", "") };
 
+            try
+            {
+                string result = "";
+                string json_request = "{\"agent\": { \"name\": \"Minecraft\", \"version\": 1 }, \"username\": \"" + JsonEncode(user) + "\", \"password\": \"" + JsonEncode(pass) + "\", \"clientToken\": \"" + JsonEncode(session.ClientID) + "\" }";
+                int code = DoHTTPSPost(Config.Main.General.AuthServer.Host,Config.Main.General.AuthServer.Port, "/api/yggdrasil/authserver/authenticate", json_request, ref result);
+                if (code == 200)
+                {
+                    if (result.Contains("availableProfiles\":[]}"))
+                    {
+                        return LoginResult.NotPremium;
+                    }
+                    else
+                    {
+                        Json.JSONData loginResponse = Json.ParseJson(result);
+                        if (loginResponse.Properties.ContainsKey("accessToken")
+                            && loginResponse.Properties.ContainsKey("selectedProfile")
+                            && loginResponse.Properties["selectedProfile"].Properties.ContainsKey("id")
+                            && loginResponse.Properties["selectedProfile"].Properties.ContainsKey("name"))
+                        {
+                            session.ID = loginResponse.Properties["accessToken"].StringValue;
+                            session.PlayerID = loginResponse.Properties["selectedProfile"].Properties["id"].StringValue;
+                            session.PlayerName = loginResponse.Properties["selectedProfile"].Properties["name"].StringValue;
+                            return LoginResult.Success;
+                        }
+                        else return LoginResult.InvalidResponse;
+                    }
+                }
+                else if (code == 403)
+                {
+                    if (result.Contains("UserMigratedException"))
+                    {
+                        return LoginResult.AccountMigrated;
+                    }
+                    else return LoginResult.WrongPassword;
+                }
+                else if (code == 503)
+                {
+                    return LoginResult.ServiceUnavailable;
+                }
+                else
+                {
+                    ConsoleIO.WriteLineFormatted("§8" + string.Format(Translations.error_http_code, code));
+                    return LoginResult.OtherError;
+                }
+            }
+            catch (System.Security.Authentication.AuthenticationException e)
+            {
+                if (Settings.Config.Logging.DebugMessages)
+                {
+                    ConsoleIO.WriteLineFormatted("§8" + e.ToString());
+                }
+                return LoginResult.SSLError;
+            }
+            catch (System.IO.IOException e)
+            {
+                if (Settings.Config.Logging.DebugMessages)
+                {
+                    ConsoleIO.WriteLineFormatted("§8" + e.ToString());
+                }
+                if (e.Message.Contains("authentication"))
+                {
+                    return LoginResult.SSLError;
+                }
+                else return LoginResult.OtherError;
+            }
+            catch (Exception e)
+            {
+                if (Settings.Config.Logging.DebugMessages)
+                {
+                    ConsoleIO.WriteLineFormatted("§8" + e.ToString());
+                }
+                return LoginResult.OtherError;
+            }
+        }
         /// <summary>
         /// Sign-in to Microsoft Account without using browser. Only works if 2FA is disabled.
         /// Might not work well in some rare cases.
@@ -675,7 +756,7 @@ namespace MinecraftClient.Protocol
             {
                 string result = "";
                 string json_request = "{ \"accessToken\": \"" + JsonEncode(currentsession.ID) + "\", \"clientToken\": \"" + JsonEncode(currentsession.ClientID) + "\", \"selectedProfile\": { \"id\": \"" + JsonEncode(currentsession.PlayerID) + "\", \"name\": \"" + JsonEncode(currentsession.PlayerName) + "\" } }";
-                int code = DoHTTPSPost("authserver.mojang.com", "/refresh", json_request, ref result);
+                int code = DoHTTPSPost("authserver.mojang.com",443, "/refresh", json_request, ref result);
                 if (code == 200)
                 {
                     if (result == null)
@@ -727,7 +808,19 @@ namespace MinecraftClient.Protocol
             {
                 string result = "";
                 string json_request = "{\"accessToken\":\"" + accesstoken + "\",\"selectedProfile\":\"" + uuid + "\",\"serverId\":\"" + serverhash + "\"}";
-                int code = DoHTTPSPost("sessionserver.mojang.com", "/session/minecraft/join", json_request, ref result);
+                int code = DoHTTPSPost("sessionserver.mojang.com",443, "/session/minecraft/join", json_request, ref result);
+                return (code >= 200 && code < 300);
+            }
+            catch { return false; }
+        }
+
+        public static bool YggdrasilSessionCheck(string uuid, string accesstoken, string serverhash)
+        {
+            try
+            {
+                string result = "";
+                string json_request = "{\"accessToken\":\"" + accesstoken + "\",\"selectedProfile\":\"" + uuid + "\",\"serverId\":\"" + serverhash + "\"}";
+                int code = DoHTTPSPost(Config.Main.General.AuthServer.Host, Config.Main.General.AuthServer.Port, "/api/yggdrasil/sessionserver/session/minecraft/join", json_request, ref result);
                 return (code >= 200 && code < 300);
             }
             catch { return false; }
@@ -747,7 +840,7 @@ namespace MinecraftClient.Protocol
             {
                 string result = "";
                 string cookies = String.Format("sid=token:{0}:{1};user={2};version={3}", accesstoken, uuid, username, Program.MCHighestVersion);
-                DoHTTPSGet("pc.realms.minecraft.net", "/worlds", cookies, ref result);
+                DoHTTPSGet("pc.realms.minecraft.net", 443,"/worlds", cookies, ref result);
                 Json.JSONData realmsWorlds = Json.ParseJson(result);
                 if (realmsWorlds.Properties.ContainsKey("servers")
                     && realmsWorlds.Properties["servers"].Type == Json.JSONData.DataType.Array
@@ -808,7 +901,7 @@ namespace MinecraftClient.Protocol
             {
                 string result = "";
                 string cookies = String.Format("sid=token:{0}:{1};user={2};version={3}", accesstoken, uuid, username, Program.MCHighestVersion);
-                int statusCode = DoHTTPSGet("pc.realms.minecraft.net", "/worlds/v1/" + worldId + "/join/pc", cookies, ref result);
+                int statusCode = DoHTTPSGet("pc.realms.minecraft.net",443, "/worlds/v1/" + worldId + "/join/pc", cookies, ref result);
                 if (statusCode == 200)
                 {
                     Json.JSONData serverAddress = Json.ParseJson(result);
@@ -845,7 +938,7 @@ namespace MinecraftClient.Protocol
         /// <param name="cookies">Cookies for making the request</param>
         /// <param name="result">Request result</param>
         /// <returns>HTTP Status code</returns>
-        private static int DoHTTPSGet(string host, string endpoint, string cookies, ref string result)
+        private static int DoHTTPSGet(string host,int port, string endpoint, string cookies, ref string result)
         {
             List<String> http_request = new()
             {
@@ -860,7 +953,7 @@ namespace MinecraftClient.Protocol
                 "",
                 ""
             };
-            return DoHTTPSRequest(http_request, host, ref result);
+            return DoHTTPSRequest(http_request, host,port, ref result);
         }
 
         /// <summary>
@@ -871,7 +964,7 @@ namespace MinecraftClient.Protocol
         /// <param name="request">Request payload</param>
         /// <param name="result">Request result</param>
         /// <returns>HTTP Status code</returns>
-        private static int DoHTTPSPost(string host, string endpoint, string request, ref string result)
+        private static int DoHTTPSPost(string host, int port, string endpoint, string request, ref string result)
         {
             List<String> http_request = new()
             {
@@ -884,7 +977,7 @@ namespace MinecraftClient.Protocol
                 "",
                 request
             };
-            return DoHTTPSRequest(http_request, host, ref result);
+            return DoHTTPSRequest(http_request, host,port, ref result);
         }
 
         /// <summary>
@@ -895,7 +988,7 @@ namespace MinecraftClient.Protocol
         /// <param name="host">Host to connect to</param>
         /// <param name="result">Request result</param>
         /// <returns>HTTP Status code</returns>
-        private static int DoHTTPSRequest(List<string> headers, string host, ref string result)
+       private static int DoHTTPSRequest(List<string> headers, string host,int port, ref string result)
         {
             string? postResult = null;
             int statusCode = 520;
@@ -907,7 +1000,7 @@ namespace MinecraftClient.Protocol
                     if (Settings.Config.Logging.DebugMessages)
                         ConsoleIO.WriteLineFormatted("§8" + string.Format(Translations.debug_request, host));
 
-                    TcpClient client = ProxyHandler.NewTcpClient(host, 443, true);
+                    TcpClient client = ProxyHandler.NewTcpClient(host, port, true);
                     SslStream stream = new(client.GetStream());
                     stream.AuthenticateAsClient(host, null, SslProtocols.Tls12, true); // Enable TLS 1.2. Hotfix for #1780
 
@@ -928,8 +1021,15 @@ namespace MinecraftClient.Protocol
 
                     if (raw_result.StartsWith("HTTP/1.1"))
                     {
-                        postResult = raw_result[(raw_result.IndexOf("\r\n\r\n") + 4)..];
                         statusCode = int.Parse(raw_result.Split(' ')[1], NumberStyles.Any, CultureInfo.CurrentCulture);
+                        if (statusCode != 204) 
+                        {
+                            postResult = raw_result[(raw_result.IndexOf("\r\n\r\n") + 4)..].Split("\r\n")[1];
+                        }
+                        else 
+                        {
+                            postResult = "No Content";
+                        }
                     }
                     else statusCode = 520; //Web server is returning an unknown error
                 }

--- a/MinecraftClient/Protocol/Session/SessionToken.cs
+++ b/MinecraftClient/Protocol/Session/SessionToken.cs
@@ -41,7 +41,7 @@ namespace MinecraftClient.Protocol.Session
             string serverHash = Crypto.CryptoHandler.GetServerHash(ServerIDhash, ServerPublicKey, Crypto.CryptoHandler.ClientAESPrivateKey);
             if (type == LoginType.mojang && ProtocolHandler.SessionCheck(PlayerID, ID, serverHash))
                 return true;
-            if (type == LoginType.Yggdrasil && ProtocolHandler.YggdrasilSessionCheck(PlayerID, ID, serverHash))
+            if (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(PlayerID, ID, serverHash))
                 return true;
             return false;
         }

--- a/MinecraftClient/Protocol/Session/SessionToken.cs
+++ b/MinecraftClient/Protocol/Session/SessionToken.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MinecraftClient.Scripting;
+using static MinecraftClient.Settings.MainConfigHealper.MainConfig.GeneralConfig;
 
 namespace MinecraftClient.Protocol.Session
 {
@@ -32,13 +33,15 @@ namespace MinecraftClient.Protocol.Session
             ServerPublicKey = null;
         }
 
-        public bool SessionPreCheck()
+        public bool SessionPreCheck(LoginType type)
         {
             if (ID == string.Empty || PlayerID == String.Empty || ServerPublicKey == null)
                 return false;
             Crypto.CryptoHandler.ClientAESPrivateKey ??= Crypto.CryptoHandler.GenerateAESPrivateKey();
             string serverHash = Crypto.CryptoHandler.GetServerHash(ServerIDhash, ServerPublicKey, Crypto.CryptoHandler.ClientAESPrivateKey);
-            if (ProtocolHandler.SessionCheck(PlayerID, ID, serverHash))
+            if (type == LoginType.mojang && ProtocolHandler.SessionCheck(PlayerID, ID, serverHash))
+                return true;
+            if (type == LoginType.Yggdrasil && ProtocolHandler.YggdrasilSessionCheck(PlayerID, ID, serverHash))
                 return true;
             return false;
         }

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
@@ -1723,6 +1723,15 @@ namespace MinecraftClient {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Yggdrasil authlib server domain name and port..
+        /// </summary>
+        internal static string Main_General_AuthlibServer {
+            get {
+                return ResourceManager.GetString("Main.General.AuthlibServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The address of the game server, &quot;Host&quot; can be filled in with domain name or IP address. (The &quot;Port&quot; field can be deleted, it will be resolved automatically).
         /// </summary>
         internal static string Main_General_login {
@@ -1741,7 +1750,7 @@ namespace MinecraftClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Account type: &quot;mojang&quot; OR &quot;microsoft&quot;. Also affects interactive login in console..
+        ///   Looks up a localized string similar to Account type: &quot;mojang&quot; OR &quot;microsoft&quot; OR &quot;yggdrasil&quot;. Also affects interactive login in console..
         /// </summary>
         internal static string Main_General_server_info {
             get {

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
@@ -799,8 +799,7 @@ namespace MinecraftClient {
         ///NOTE: This is an experimental feature, the bot can be slow at times, you need to walk with a normal speed and to sometimes stop for it to be able to keep up with you
         ///It&apos;s similar to making animals follow you when you&apos;re holding food in your hand.
         ///This is due to a slow pathfinding algorithm, we&apos;re working on getting a better one
-        ///You can tweak the update limit and find what works best for you. (NOTE: Do not but a very low one, because you might achieve the opposite,
-        /// [rest of string was truncated]&quot;;.
+        ///You can tweak the update limit and find what works best for you. (NOTE: Do not but a very low one, because you might achieve the opposite,        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ChatBot_FollowPlayer {
             get {
@@ -1128,9 +1127,9 @@ namespace MinecraftClient {
                 return ResourceManager.GetString("ChatBot.WebSocketBot", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Allow IP aliases, such as "localhost" or if using containers then the container name can be used...
+        ///   Looks up a localized string similar to Allow IP aliases, such as &quot;localhost&quot; or if using containers then the container name can be used....
         /// </summary>
         internal static string ChatBot_WebSocketBot_AllowIpAlias {
             get {
@@ -1733,6 +1732,15 @@ namespace MinecraftClient {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Yggdrasil authlib server domain name and port..
+        /// </summary>
+        internal static string Main_General_AuthlibServer {
+            get {
+                return ResourceManager.GetString("Main.General.AuthlibServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The address of the game server, &quot;Host&quot; can be filled in with domain name or IP address. (The &quot;Port&quot; field can be deleted, it will be resolved automatically).
         /// </summary>
         internal static string Main_General_login {
@@ -1751,7 +1759,7 @@ namespace MinecraftClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Account type: &quot;mojang&quot; OR &quot;microsoft&quot;. Also affects interactive login in console..
+        ///   Looks up a localized string similar to Account type: &quot;mojang&quot; OR &quot;microsoft&quot; OR &quot;yggdrasil&quot;. Also affects interactive login in console..
         /// </summary>
         internal static string Main_General_server_info {
             get {

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
@@ -799,7 +799,8 @@ namespace MinecraftClient {
         ///NOTE: This is an experimental feature, the bot can be slow at times, you need to walk with a normal speed and to sometimes stop for it to be able to keep up with you
         ///It&apos;s similar to making animals follow you when you&apos;re holding food in your hand.
         ///This is due to a slow pathfinding algorithm, we&apos;re working on getting a better one
-        ///You can tweak the update limit and find what works best for you. (NOTE: Do not but a very low one, because you might achieve the opposite,        /// [rest of string was truncated]&quot;;.
+        ///You can tweak the update limit and find what works best for you. (NOTE: Do not but a very low one, because you might achieve the opposite,
+        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ChatBot_FollowPlayer {
             get {
@@ -1125,6 +1126,15 @@ namespace MinecraftClient {
         internal static string ChatBot_WebSocketBot {
             get {
                 return ResourceManager.GetString("ChatBot.WebSocketBot", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Allow IP aliases, such as "localhost" or if using containers then the container name can be used...
+        /// </summary>
+        internal static string ChatBot_WebSocketBot_AllowIpAlias {
+            get {
+                return ResourceManager.GetString("ChatBot.WebSocketBot.AllowIpAlias", resourceCulture);
             }
         }
         
@@ -1723,15 +1733,6 @@ namespace MinecraftClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Yggdrasil authlib server domain name and port..
-        /// </summary>
-        internal static string Main_General_AuthlibServer {
-            get {
-                return ResourceManager.GetString("Main.General.AuthlibServer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The address of the game server, &quot;Host&quot; can be filled in with domain name or IP address. (The &quot;Port&quot; field can be deleted, it will be resolved automatically).
         /// </summary>
         internal static string Main_General_login {
@@ -1750,7 +1751,7 @@ namespace MinecraftClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Account type: &quot;mojang&quot; OR &quot;microsoft&quot; OR &quot;yggdrasil&quot;. Also affects interactive login in console..
+        ///   Looks up a localized string similar to Account type: &quot;mojang&quot; OR &quot;microsoft&quot;. Also affects interactive login in console..
         /// </summary>
         internal static string Main_General_server_info {
             get {

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
@@ -724,7 +724,7 @@ Usage examples: "/tell &lt;mybot&gt; connect Server1", "/connect Server2"</value
     <value>Microsoft Account sign-in method: "mcc" OR "browser". If the login always fails, please try to use the "browser" once.</value>
   </data>
   <data name="Main.General.server_info" xml:space="preserve">
-    <value>Account type: "mojang" OR "microsoft". Also affects interactive login in console.</value>
+    <value>Account type: "mojang" OR "microsoft" OR "yggdrasil". Also affects interactive login in console.</value>
   </data>
   <data name="MCSettings" xml:space="preserve">
     <value>Settings below are sent to the server and only affect server-side things like your skin.</value>
@@ -845,5 +845,8 @@ If the connection to the Minecraft game server is blocked by the firewall, set E
   </data>
   <data name="Main.Advanced.ignore_invalid_playername" xml:space="preserve">
     <value>Ignore invalid player name</value>
+  </data>
+  <data name="Main.General.AuthlibServer" xml:space="preserve">
+    <value>Yggdrasil authlib server domain name and port.</value>
   </data>
 </root>

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
@@ -724,7 +724,7 @@ Usage examples: "/tell &lt;mybot&gt; connect Server1", "/connect Server2"</value
     <value>Microsoft Account sign-in method: "mcc" OR "browser". If the login always fails, please try to use the "browser" once.</value>
   </data>
   <data name="Main.General.server_info" xml:space="preserve">
-    <value>Account type: "mojang" OR "microsoft" OR "yggdrasil". Also affects interactive login in console.</value>
+    <value>Account type: "mojang" OR "microsoft". Also affects interactive login in console.</value>
   </data>
   <data name="MCSettings" xml:space="preserve">
     <value>Settings below are sent to the server and only affect server-side things like your skin.</value>
@@ -843,10 +843,10 @@ If the connection to the Minecraft game server is blocked by the firewall, set E
   <data name="ChatBot.WebSocketBot.DebugMode" xml:space="preserve">
     <value>This setting is for developers who are developing a library that uses this chat bot to remotely execute procedures/commands/functions.</value>
   </data>
+  <data name="ChatBot.WebSocketBot.AllowIpAlias" xml:space="preserve">
+    <value>Allow IP aliases, such as "localhost" or if using containers then the container name can be used...</value>
+  </data>
   <data name="Main.Advanced.ignore_invalid_playername" xml:space="preserve">
     <value>Ignore invalid player name</value>
-  </data>
-  <data name="Main.General.AuthlibServer" xml:space="preserve">
-    <value>Yggdrasil authlib server domain name and port.</value>
   </data>
 </root>

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
@@ -724,7 +724,7 @@ Usage examples: "/tell &lt;mybot&gt; connect Server1", "/connect Server2"</value
     <value>Microsoft Account sign-in method: "mcc" OR "browser". If the login always fails, please try to use the "browser" once.</value>
   </data>
   <data name="Main.General.server_info" xml:space="preserve">
-    <value>Account type: "mojang" OR "microsoft". Also affects interactive login in console.</value>
+    <value>Account type: "mojang" OR "microsoft" OR "yggdrasil". Also affects interactive login in console.</value>
   </data>
   <data name="MCSettings" xml:space="preserve">
     <value>Settings below are sent to the server and only affect server-side things like your skin.</value>
@@ -848,5 +848,8 @@ If the connection to the Minecraft game server is blocked by the firewall, set E
   </data>
   <data name="Main.Advanced.ignore_invalid_playername" xml:space="preserve">
     <value>Ignore invalid player name</value>
+  </data>
+  <data name="Main.General.AuthlibServer" xml:space="preserve">
+    <value>Yggdrasil authlib server domain name and port.</value>
   </data>
 </root>

--- a/MinecraftClient/Resources/Translations/Translations.Designer.cs
+++ b/MinecraftClient/Resources/Translations/Translations.Designer.cs
@@ -5374,11 +5374,11 @@ namespace MinecraftClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Avaliable players:.
+        ///   Looks up a localized string similar to Avaliable profiles:.
         /// </summary>
-        internal static string mcc_avaliable_players {
+        internal static string mcc_avaliable_profiles {
             get {
-                return ResourceManager.GetString("mcc.avaliable_players", resourceCulture);
+                return ResourceManager.GetString("mcc.avaliable_profiles", resourceCulture);
             }
         }
         
@@ -5756,20 +5756,20 @@ namespace MinecraftClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select a player from available players:.
+        ///   Looks up a localized string similar to Select a profile from available profiles:.
         /// </summary>
-        internal static string mcc_select_player {
+        internal static string mcc_select_profile {
             get {
-                return ResourceManager.GetString("mcc.select_player", resourceCulture);
+                return ResourceManager.GetString("mcc.select_profile", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Selected player:.
+        ///   Looks up a localized string similar to Selected profile:.
         /// </summary>
-        internal static string mcc_selected_player {
+        internal static string mcc_selected_profile {
             get {
-                return ResourceManager.GetString("mcc.selected_player", resourceCulture);
+                return ResourceManager.GetString("mcc.selected_profile", resourceCulture);
             }
         }
         

--- a/MinecraftClient/Resources/Translations/Translations.Designer.cs
+++ b/MinecraftClient/Resources/Translations/Translations.Designer.cs
@@ -5374,6 +5374,15 @@ namespace MinecraftClient {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avaliable players:.
+        /// </summary>
+        internal static string mcc_avaliable_players {
+            get {
+                return ResourceManager.GetString("mcc.avaliable_players", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The old MinecraftClient.ini has been backed up as {0}.
         /// </summary>
         internal static string mcc_backup_old_config {
@@ -5743,6 +5752,24 @@ namespace MinecraftClient {
         internal static string mcc_run_with_default_settings {
             get {
                 return ResourceManager.GetString("mcc.run_with_default_settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select a player from available players:.
+        /// </summary>
+        internal static string mcc_select_player {
+            get {
+                return ResourceManager.GetString("mcc.select_player", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Selected player:.
+        /// </summary>
+        internal static string mcc_selected_player {
+            get {
+                return ResourceManager.GetString("mcc.selected_player", resourceCulture);
             }
         }
         

--- a/MinecraftClient/Resources/Translations/Translations.resx
+++ b/MinecraftClient/Resources/Translations/Translations.resx
@@ -2121,13 +2121,13 @@ Logging in...</value>
   <data name="cmd.inventory.shiftrightclick" xml:space="preserve">
     <value>Shift right-clicking slot {0} in window #{1}</value>
   </data>
-  <data name="mcc.avaliable_players" xml:space="preserve">
-    <value>Avaliable players:</value>
+  <data name="mcc.avaliable_profiles" xml:space="preserve">
+    <value>Avaliable profiles:</value>
   </data>
-  <data name="mcc.selected_player" xml:space="preserve">
-    <value>Selected player:</value>
+  <data name="mcc.selected_profile" xml:space="preserve">
+    <value>Selected profile:</value>
   </data>
-  <data name="mcc.select_player" xml:space="preserve">
-    <value>Select a player from available players:</value>
+  <data name="mcc.select_profile" xml:space="preserve">
+    <value>Select a profile from available profiles:</value>
   </data>
 </root>

--- a/MinecraftClient/Resources/Translations/Translations.resx
+++ b/MinecraftClient/Resources/Translations/Translations.resx
@@ -2121,4 +2121,13 @@ Logging in...</value>
   <data name="cmd.inventory.shiftrightclick" xml:space="preserve">
     <value>Shift right-clicking slot {0} in window #{1}</value>
   </data>
+  <data name="mcc.avaliable_players" xml:space="preserve">
+    <value>Avaliable players:</value>
+  </data>
+  <data name="mcc.selected_player" xml:space="preserve">
+    <value>Selected player:</value>
+  </data>
+  <data name="mcc.select_player" xml:space="preserve">
+    <value>Select a player from available players:</value>
+  </data>
 </root>

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -498,7 +498,7 @@ namespace MinecraftClient
                     public AuthlibServer AuthServer = new(string.Empty);
                   
 
-                    public enum LoginType { mojang, microsoft,Yggdrasil };
+                    public enum LoginType { mojang, microsoft,yggdrasil };
 
                     public enum LoginMethod { mcc, browser };
                 }

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -494,8 +494,11 @@ namespace MinecraftClient
 
                     [TomlInlineComment("$Main.General.method$")]
                     public LoginMethod Method = LoginMethod.mcc;
+                    [TomlInlineComment("$Main.General.AuthlibServer$")]
+                    public AuthlibServer AuthServer = new(string.Empty);
+                  
 
-                    public enum LoginType { mojang, microsoft };
+                    public enum LoginType { mojang, microsoft,Yggdrasil };
 
                     public enum LoginMethod { mcc, browser };
                 }
@@ -683,6 +686,29 @@ namespace MinecraftClient
                     }
 
                     public ServerInfoConfig(string Host, ushort Port)
+                    {
+                        this.Host = Host.Split(new[] { ":", "：" }, StringSplitOptions.None)[0];
+                        this.Port = Port;
+                    }
+                }
+                public struct AuthlibServer
+                {
+                    public string Host = string.Empty;
+                    public int Port = 443;
+
+                    public AuthlibServer(string Host)
+                    {
+                        string[] sip = Host.Split(new[] { ":", "：" }, StringSplitOptions.None);
+                        this.Host = sip[0];
+
+                        if (sip.Length > 1)
+                        {
+                            try { this.Port = Convert.ToUInt16(sip[1]); }
+                            catch (FormatException) { }
+                        }
+                    }
+
+                    public AuthlibServer(string Host, ushort Port)
                     {
                         this.Host = Host.Split(new[] { ":", "：" }, StringSplitOptions.None)[0];
                         this.Port = Port;


### PR DESCRIPTION
## How to use
To use Yggdrasil, u need to change the following in MinecraftClient.ini.
```
AccountType = "yggdrasil"
AuthServer = { Host = "littleskin.cn", Port = 443 }
```
When facing a multi-player account, the `selectedProfile` is None and u need to input the player name to select.
## Problems
- May meeting some errors when trying to join a [Velocity](https://papermc.io/software/velocity) Server.
- I'm poor in C#, some logics may be strange.

Some code comes from https://github.com/Hikari1nVoid/MCC-authlib ,but there are many errors in the original fork.