### PR TITLE
Add an IP lookup to the WebSocketBot

### DIFF
--- a/MinecraftClient/ChatBots/WebSocketBot.cs
+++ b/MinecraftClient/ChatBots/WebSocketBot.cs
@@ -291,7 +291,17 @@ public class WebSocketBot : ChatBot
 
     public WebSocketBot()
     {
-        var match = Regex.Match(Config.Ip!, @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}");
+        // Lookup the given address
+        try
+        {
+            _ip = Dns.GetHostAddresses(Config.Ip!).First().ToString();
+        }
+        catch (Exception e)
+        {
+            // Set Ip to a non-acceptable value to fail the Ip check
+            _ip = "not found";
+        }
+        var match = Regex.Match(_ip, @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}");
 
         if (!match.Success)
         {
@@ -305,7 +315,6 @@ public class WebSocketBot : ChatBot
             return;
         }
 
-        _ip = Config.Ip;
         _port = Config.Port;
         _password = Config.Password;
         _authenticatedSessions = new();

--- a/MinecraftClient/ChatBots/WebSocketBot.cs
+++ b/MinecraftClient/ChatBots/WebSocketBot.cs
@@ -287,13 +287,21 @@ public class WebSocketBot : ChatBot
 
         [TomlInlineComment("$ChatBot.WebSocketBot.DebugMode$")]
         public bool DebugMode = false;
+
+        [TomlInlineComment("$ChatBot.WebSocketBot.AllowIpAlias$")]
+        public bool AllowIpAlias = false;
     }
 
     public WebSocketBot()
     {
+        _password = Config.Password;
+        _authenticatedSessions = new();
+        _waitingEvents = new();
+
         var match = Regex.Match(Config.Ip!, @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}");
 
-        if (!match.Success)
+        // If AllowIpAlias is set to true in the config, then always ignore this check
+        if (!match.Success & !Config.AllowIpAlias!)
         {
             LogToConsole(Translations.bot_WebSocketBot_failed_to_start_ip);
             return;
@@ -307,9 +315,6 @@ public class WebSocketBot : ChatBot
 
         _ip = Config.Ip;
         _port = Config.Port;
-        _password = Config.Password;
-        _authenticatedSessions = new();
-        _waitingEvents = new();
     }
 
     public override void Initialize()

--- a/MinecraftClient/ChatBots/WebSocketBot.cs
+++ b/MinecraftClient/ChatBots/WebSocketBot.cs
@@ -291,17 +291,7 @@ public class WebSocketBot : ChatBot
 
     public WebSocketBot()
     {
-        // Lookup the given address
-        try
-        {
-            _ip = Dns.GetHostAddresses(Config.Ip!).First().ToString();
-        }
-        catch (Exception e)
-        {
-            // Set Ip to a non-acceptable value to fail the Ip check
-            _ip = "not found";
-        }
-        var match = Regex.Match(_ip, @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}");
+        var match = Regex.Match(Config.Ip!, @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}");
 
         if (!match.Success)
         {
@@ -315,6 +305,7 @@ public class WebSocketBot : ChatBot
             return;
         }
 
+        _ip = Config.Ip;
         _port = Config.Port;
         _password = Config.Password;
         _authenticatedSessions = new();

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.Designer.cs
@@ -799,7 +799,8 @@ namespace MinecraftClient {
         ///NOTE: This is an experimental feature, the bot can be slow at times, you need to walk with a normal speed and to sometimes stop for it to be able to keep up with you
         ///It&apos;s similar to making animals follow you when you&apos;re holding food in your hand.
         ///This is due to a slow pathfinding algorithm, we&apos;re working on getting a better one
-        ///You can tweak the update limit and find what works best for you. (NOTE: Do not but a very low one, because you might achieve the opposite,        /// [rest of string was truncated]&quot;;.
+        ///You can tweak the update limit and find what works best for you. (NOTE: Do not but a very low one, because you might achieve the opposite,
+        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ChatBot_FollowPlayer {
             get {
@@ -1125,6 +1126,15 @@ namespace MinecraftClient {
         internal static string ChatBot_WebSocketBot {
             get {
                 return ResourceManager.GetString("ChatBot.WebSocketBot", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Allow IP aliases, such as "localhost" or if using containers then the container name can be used...
+        /// </summary>
+        internal static string ChatBot_WebSocketBot_AllowIpAlias {
+            get {
+                return ResourceManager.GetString("ChatBot.WebSocketBot.AllowIpAlias", resourceCulture);
             }
         }
         

--- a/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
+++ b/MinecraftClient/Resources/ConfigComments/ConfigComments.resx
@@ -843,6 +843,9 @@ If the connection to the Minecraft game server is blocked by the firewall, set E
   <data name="ChatBot.WebSocketBot.DebugMode" xml:space="preserve">
     <value>This setting is for developers who are developing a library that uses this chat bot to remotely execute procedures/commands/functions.</value>
   </data>
+  <data name="ChatBot.WebSocketBot.AllowIpAlias" xml:space="preserve">
+    <value>Allow IP aliases, such as "localhost" or if using containers then the container name can be used...</value>
+  </data>
   <data name="Main.Advanced.ignore_invalid_playername" xml:space="preserve">
     <value>Ignore invalid player name</value>
   </data>

--- a/MinecraftClient/Resources/Translations/Translations.Designer.cs
+++ b/MinecraftClient/Resources/Translations/Translations.Designer.cs
@@ -2450,6 +2450,15 @@ namespace MinecraftClient {
                 return ResourceManager.GetString("chatbot.reconnect", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string ChatBot_WebSocketBot_AllowIpAlias {
+            get {
+                return ResourceManager.GetString("ChatBot.WebSocketBot.AllowIpAlias", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to .


### PR DESCRIPTION
To allow for running the WebSocket Bot easily in containers I wanted a way to be able to have the bot do a DNS lookup of a given string, this PR adds the desired functionality.

I have tested it with a few cases, including that the default "127.0.0.1" works (NOTE: I'm using my Python bindings to test this which can be found at [mcc.py](https://github.com/Zorua162/mcc.py). 
However, with these changes "localhost" can now also be used as an option. The IP still gets resolved to "127.0.0.1", but its a nice quality of life thing.

I also tested the case of Non-sensical IPs such as "127.0.0.0.1", which resulted in the expected error, and IPs such as "aaa", which also resulted in the expected error.

This implementation **doesn't** allow dangerous wildcards as the hostname such as "*", however if the Dns.GetHostAddress method is disliked, then this method may need to be allowed instead, otherwise running the WebHook bot in a container simply be too complicated to be worth doing.

