### PR TITLE
Websocket bot: Create new Responder object that will respond to the session's new name

### DIFF
--- a/MinecraftClient/ChatBots/WebSocketBot.cs
+++ b/MinecraftClient/ChatBots/WebSocketBot.cs
@@ -420,6 +420,9 @@ public class WebSocketBot : ChatBot
                         _authenticatedSessions.Add(newId);
                     }
 
+                    // Update the responder to the new session id
+                    responder = new WsCommandResponder(this, newId, cmd.Command, cmd.RequestId);
+
                     responder.SendSuccessResponse(
                         responder.Quote("The session ID was successfully changed to: '" + newId + "'"), true);
                     LogToConsole(string.Format(Translations.bot_WebSocketBot_session_id_changed, sessionId, newId));


### PR DESCRIPTION
I noticed that I wasn't getting any reply when I changed my session name, upon looking at the code it turns out this response was getting sent to the old session name. I have added a line which creates a new responder object with the new id to fix this. 