### PR TITLE
Restore ability to login with Microsoft broken after Yggdrasil authentication implementation

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -538,8 +538,7 @@ namespace MinecraftClient.Protocol.Handlers
 
                 if (needCheckSession)
                 {
-                    bool notYggdrasil = type == LoginType.mojang || type == LoginType.microsoft;
-                    if ((notYggdrasil && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash)) || (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
+                    if (ProtocolHandler.SessionCheck(uuid, sessionID, serverHash, type))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -538,7 +538,8 @@ namespace MinecraftClient.Protocol.Handlers
 
                 if (needCheckSession)
                 {
-                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash)) || (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
+                    bool notYggdrasil = type == LoginType.mojang || type == LoginType.microsoft;
+                    if ((notYggdrasil && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash)) || (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -2619,8 +2619,7 @@ namespace MinecraftClient.Protocol.Handlers
                 if (needCheckSession)
                 {
                     string serverHash = CryptoHandler.GetServerHash(serverIDhash, serverPublicKey, secretKey);
-                    bool notYggdrasil = type == LoginType.mojang || type == LoginType.microsoft;
-                    if ((notYggdrasil && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash) )|| (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
+                    if (ProtocolHandler.SessionCheck(uuid, sessionID, serverHash, type))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -2619,8 +2619,8 @@ namespace MinecraftClient.Protocol.Handlers
                 if (needCheckSession)
                 {
                     string serverHash = CryptoHandler.GetServerHash(serverIDhash, serverPublicKey, secretKey);
-
-                    if ((type == LoginType.mojang && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash) )|| (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
+                    bool notYggdrasil = type == LoginType.mojang || type == LoginType.microsoft;
+                    if ((notYggdrasil && ProtocolHandler.SessionCheck(uuid, sessionID, serverHash) )|| (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(uuid, sessionID, serverHash)))
                     {
                         session.ServerIDhash = serverIDhash;
                         session.ServerPublicKey = serverPublicKey;

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -881,26 +881,19 @@ namespace MinecraftClient.Protocol
         /// <param name="user">Username</param>
         /// <param name="accesstoken">Session ID</param>
         /// <param name="serverhash">Server ID</param>
+        /// <param name="type">LoginType</param>
         /// <returns>TRUE if session was successfully checked</returns>
-        public static bool SessionCheck(string uuid, string accesstoken, string serverhash)
+        public static bool SessionCheck(string uuid, string accesstoken, string serverhash, LoginType type)
         {
             try
             {
                 string result = "";
                 string json_request = "{\"accessToken\":\"" + accesstoken + "\",\"selectedProfile\":\"" + uuid + "\",\"serverId\":\"" + serverhash + "\"}";
-                int code = DoHTTPSPost("sessionserver.mojang.com",443, "/session/minecraft/join", json_request, ref result);
-                return (code >= 200 && code < 300);
-            }
-            catch { return false; }
-        }
+                string host = type == LoginType.yggdrasil ? Config.Main.General.AuthServer.Host : "sessionserver.mojang.com";
+                int port = type == LoginType.yggdrasil ? Config.Main.General.AuthServer.Port : 443;
+                string endpoint = type == LoginType.yggdrasil ? "/api/yggdrasil/sessionserver/session/minecraft/join" : "/session/minecraft/join";
 
-        public static bool YggdrasilSessionCheck(string uuid, string accesstoken, string serverhash)
-        {
-            try
-            {
-                string result = "";
-                string json_request = "{\"accessToken\":\"" + accesstoken + "\",\"selectedProfile\":\"" + uuid + "\",\"serverId\":\"" + serverhash + "\"}";
-                int code = DoHTTPSPost(Config.Main.General.AuthServer.Host, Config.Main.General.AuthServer.Port, "/api/yggdrasil/sessionserver/session/minecraft/join", json_request, ref result);
+                int code = DoHTTPSPost(host, port, endpoint, json_request, ref result);
                 return (code >= 200 && code < 300);
             }
             catch { return false; }

--- a/MinecraftClient/Protocol/Session/SessionToken.cs
+++ b/MinecraftClient/Protocol/Session/SessionToken.cs
@@ -39,7 +39,8 @@ namespace MinecraftClient.Protocol.Session
                 return false;
             Crypto.CryptoHandler.ClientAESPrivateKey ??= Crypto.CryptoHandler.GenerateAESPrivateKey();
             string serverHash = Crypto.CryptoHandler.GetServerHash(ServerIDhash, ServerPublicKey, Crypto.CryptoHandler.ClientAESPrivateKey);
-            if (type == LoginType.mojang && ProtocolHandler.SessionCheck(PlayerID, ID, serverHash))
+            bool notYggdrasil = type == LoginType.mojang || type == LoginType.microsoft;
+            if (notYggdrasil && ProtocolHandler.SessionCheck(PlayerID, ID, serverHash))
                 return true;
             if (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(PlayerID, ID, serverHash))
                 return true;

--- a/MinecraftClient/Protocol/Session/SessionToken.cs
+++ b/MinecraftClient/Protocol/Session/SessionToken.cs
@@ -39,10 +39,7 @@ namespace MinecraftClient.Protocol.Session
                 return false;
             Crypto.CryptoHandler.ClientAESPrivateKey ??= Crypto.CryptoHandler.GenerateAESPrivateKey();
             string serverHash = Crypto.CryptoHandler.GetServerHash(ServerIDhash, ServerPublicKey, Crypto.CryptoHandler.ClientAESPrivateKey);
-            bool notYggdrasil = type == LoginType.mojang || type == LoginType.microsoft;
-            if (notYggdrasil && ProtocolHandler.SessionCheck(PlayerID, ID, serverHash))
-                return true;
-            if (type == LoginType.yggdrasil && ProtocolHandler.YggdrasilSessionCheck(PlayerID, ID, serverHash))
+            if (ProtocolHandler.SessionCheck(PlayerID, ID, serverHash, type))
                 return true;
             return false;
         }


### PR DESCRIPTION
Implementation of Yggdrasil login broke Microsoft login by not including it to the session check conditionals.
This PR fixes it.