### PR TITLE
Fixed chat issues

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -484,6 +484,7 @@ namespace MinecraftClient.Protocol.Handlers
 
         private bool HandlePlayPackets(int packetId, Queue<byte> packetData)
         {
+            try{
             switch (packetPalette.GetIncommingTypeById(packetId))
             {
                 case PacketTypesIn.KeepAlive: // Keep Alive (Play)
@@ -797,7 +798,7 @@ namespace MinecraftClient.Protocol.Handlers
 
                         var chatInfo = Json.ParseJson(chatName).Properties;
                         var senderDisplayName =
-                            (chatInfo.ContainsKey("insertion") ? chatInfo["insertion"] : chatInfo["text"])
+                            (chatInfo.ContainsKey("insertion") ? chatInfo["insertion"] : (chatInfo.ContainsKey("text") ? chatInfo["text"] : ""))
                             .StringValue;
                         string? senderTeamName = null;
                         var messageTypeEnum =
@@ -909,7 +910,7 @@ namespace MinecraftClient.Protocol.Handlers
                         var chatInfo =
                             Json.ParseJson(targetName ?? chatName).Properties;
                         var senderDisplayName =
-                            (chatInfo.ContainsKey("insertion") ? chatInfo["insertion"] : chatInfo["text"])
+                            (chatInfo.ContainsKey("insertion") ? chatInfo["insertion"] : (chatInfo.ContainsKey("text") ? chatInfo["text"] : ""))
                             .StringValue;
                         string? senderTeamName = null;
                         if (targetName != null &&
@@ -2570,6 +2571,9 @@ namespace MinecraftClient.Protocol.Handlers
             }
 
             return true; //Packet processed
+            }catch(Exception exception){
+                exception.printStackTrace();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed issues with chat packets

```
Unhandled exception. System.IO.InvalidDataException: Failed to process incoming packet of type ChatMessage. (PacketID: 55, Protocol: 764, LoginPhase: False, InnerException: System.Collections.Generic.KeyNotFoundException).

 ---> System.Collections.Generic.KeyNotFoundException: The given key 'text' was not present in the dictionary.

   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)

   at MinecraftClient.Protocol.Handlers.Protocol18Handler.HandlePlayPackets(Int32 packetId, Queue`1 packetData)

   at MinecraftClient.Protocol.Handlers.Protocol18Handler.HandlePacket(Int32 packetId, Queue`1 packetData)

   --- End of inner exception stack trace ---

   at MinecraftClient.Protocol.Handlers.Protocol18Handler.HandlePacket(Int32 packetId, Queue`1 packetData)

   at MinecraftClient.Protocol.Handlers.Protocol18Handler.Updater(Object o)

   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

--- End of stack trace from previous location ---

   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

Aborted (core dumped)

```