### PR TITLE
fix(Protocol18.cs): OperationCanceledException when /reco or /quit

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -293,6 +293,10 @@ namespace MinecraftClient.Protocol.Handlers
                             break;
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
                 catch (System.IO.IOException)
                 {
                     break;


### PR DESCRIPTION
Tested version:
- 1.20.1 Forge

Occasionally get OperationCanceledException when typing /reco or /quit

```
> Unhandled exception. System.OperationCanceledException: The operation was canceled.
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Collections.Concurrent.BlockingCollection`1.TryAddWithNoTimeValidation(T item, Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Collections.Concurrent.BlockingCollection`1.Add(T item, CancellationToken cancellationToken)
   at MinecraftClient.Protocol.Handlers.Protocol18Handler.PacketReader(Object o)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
Aborted
```

Add `catch OperationCanceledException` to `MinecraftClient/Protocol/Handlers/Protocol18.cs -> Protocol18Handler -> PacketReader()` then the client can normally reconnect and quit