### PR TITLE
Fixed a crash on Entity Metadata

### DIFF
--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -735,11 +735,11 @@ namespace MinecraftClient.Protocol.Handlers
                         value = ReadNextString(cache);
                         break;
                     case EntityMetaDataType.Chat: // Chat
-                        value = ReadNextString(cache);
+                        value = ReadNextChat(cache);
                         break;
                     case EntityMetaDataType.OptionalChat: // Optional Chat
                         if (ReadNextBool(cache))
-                            value = ReadNextString(cache);
+                            value = ReadNextChat(cache);
                         break;
                     case EntityMetaDataType.Slot: // Slot
                         value = ReadNextItemSlot(cache, itemPalette);


### PR DESCRIPTION
The issue was that Chat was being read as a string instead of as NBT structure in 1.20.4