### PR TITLE
Fix general issues with logging in/relogging

### DIFF
--- a/MinecraftClient/ChatBots/AutoRelog.cs
+++ b/MinecraftClient/ChatBots/AutoRelog.cs
@@ -137,9 +137,10 @@ namespace MinecraftClient.ChatBots
         {
             double delay = random.NextDouble() * (Config.Delay.max - Config.Delay.min) + Config.Delay.min;
             LogDebugToConsole(string.Format(string.IsNullOrEmpty(msg) ? Translations.bot_autoRelog_reconnect_always : Translations.bot_autoRelog_reconnect, msg));
-            LogToConsole(string.Format(Translations.bot_autoRelog_wait, delay));
-            System.Threading.Thread.Sleep((int)Math.Floor(delay * 1000));
-            ReconnectToTheServer();
+            
+            // TODO: Change this translation string to add the retries left text
+            LogToConsole(string.Format(Translations.bot_autoRelog_wait, delay) + $" ({Config.Retries - Configs._BotRecoAttempts} retries left)");
+            ReconnectToTheServer(Config.Retries - Configs._BotRecoAttempts, (int)Math.Floor(delay), true);
         }
 
         public static bool OnDisconnectStatic(DisconnectReason reason, string message)

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -398,7 +398,12 @@ namespace MinecraftClient
         /// </summary>
         private static void InitializeClient()
         {
-            InternalConfig.MinecraftVersion = Config.Main.Advanced.MinecraftVersion;
+            // Ensure that we use the provided Minecraft version if we can't connect automatically.
+            //
+            // useMcVersionOnce is set to true on HandleFailure()
+            // whenever we are unable to connect to the server and the user provides a version number.
+            if (!useMcVersionOnce)
+                InternalConfig.MinecraftVersion = Config.Main.Advanced.MinecraftVersion;
 
             SessionToken session = new();
             PlayerKeyPair? playerKeyPair = null;
@@ -749,7 +754,7 @@ namespace MinecraftClient
                     if (InternalConfig.MinecraftVersion != "")
                     {
                         useMcVersionOnce = true;
-                        Restart();
+                        Restart(0, true);
                         return;
                     }
                 }

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -406,7 +406,7 @@ namespace MinecraftClient
             ProtocolHandler.LoginResult result = ProtocolHandler.LoginResult.LoginRequired;
 
             string loginLower = ToLowerIfNeed(InternalConfig.Account.Login);
-            if (InternalConfig.Account.Password == "-")
+            if (InternalConfig.Account.Password == "-" || InternalConfig.Account.Password == string.Empty)
             {
                 ConsoleIO.WriteLineFormatted("§8" + Translations.mcc_offline, acceptnewlines: true);
                 result = ProtocolHandler.LoginResult.Success;


### PR DESCRIPTION
Closes #2691, hopefully, by having AutoRelog handle reconnecting when it is enabled.
When it is disabled, it reverts to the basic reconnection handler found in `McClient`.

Also fixes the following issues:

---

- Overriding the version when joining a server that does not broadcast it's protocol version (i.e. a Minecraft server with Query/Server List Ping disabled, or a server behind ViaVersion (always returns protocol version -1)).

It started ignoring the version that was typed in the console and started prioritizing the version in the config.
Commit c78245c fixes that by passing parameters to the restart functions being called, and utilizing variables that are supposed to be used for this reason, that was somehow no longer being used.

---

- Offline client reconnects by authenticating with Mojang

Happened while testing the original issue, doing `/reco` during the restart handler seemed to authenticate with Mojang using offline credentials.
This has been fixed by adding a check for an empty string in the offline authentication logic.