### PR TITLE
Fix(PacketType18Handler.cs): 1.20 Packet Palette

### DIFF
--- a/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
+++ b/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
@@ -65,6 +65,7 @@ namespace MinecraftClient.Protocol.Handlers
                 <= Protocol18Handler.MC_1_19_2_Version => new PacketPalette1192(),
                 <= Protocol18Handler.MC_1_19_3_Version => new PacketPalette1193(),
                 <= Protocol18Handler.MC_1_19_4_Version => new PacketPalette1194(),
+                <= Protocol18Handler.MC_1_20_Version => new PacketPalette1194(),
                 <= Protocol18Handler.MC_1_20_2_Version => new PacketPalette1202(),
                 _ => new PacketPalette1204()
             };


### PR DESCRIPTION
Fix #2704 

The commit [Implemented 1.20.3](https://github.com/MCCTeam/Minecraft-Console-Client/commit/790e0bfe551397db1ba166732dc71ce29b61b0af#diff-c2f8a08cdba767fd5daf7ad820e7823e93b966674a8d9be571d2e51a752b8cd9) edited `PacketType18Handler.cs`

```diff
- < Protocol18Handler.MC_1_20_2_Version => new PacketPalette1194(),
- _ => new PacketPalette1202()
+ <= Protocol18Handler.MC_1_19_4_Version => new PacketPalette1194(),
+ <= Protocol18Handler.MC_1_20_2_Version => new PacketPalette1202(),
+ _ => new PacketPalette1204()
```

crashes the MCC at Protocol 763 (Protocol18Handler.MC_1_20_Version, 1.20 and 1.20.1) which works fine with PacketPalette1194 instead of 1202.