### PR TITLE
Add the ability to be able to use different platforms with the Dockerfile

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -5,6 +5,10 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0
 # Then replace the <version> with a version of your choice (Example: MCC_VERSION=20220817-29)
 #ENV MCC_VERSION=<version>
 
+# IF you want to use a specific platform then specific the ENV MCC_PLATFORM
+# For example to use arm set the environment variable: MCC_PLATFORM=linux-arm64
+# `docker run -e MCC_PLATFORM=linux-arm64 -it localhost/minecraft-console-client`
+
 # Copy over the script and give it execution permissions
 COPY start-latest.sh /opt/start-latest.sh
 RUN chmod +x /opt/start-latest.sh

--- a/Docker/start-latest.sh
+++ b/Docker/start-latest.sh
@@ -2,6 +2,8 @@
 
 cd /opt/data || exit 1
 
+echo "platform is ${MCC_PLATFORM}"
+
 if [ -e "./MinecraftClient" -a -n "$MCC_SKIP_REDOWNLOAD" ]; then
   echo "Skip re-download MinecraftClient"
 else
@@ -15,7 +17,7 @@ else
   echo "Donwloading MinecraftClient for ${RELEASE_TAG}"
 
   # Download the specified build or the latest one
-  curl -L https://github.com/MCCTeam/Minecraft-Console-Client/releases/download/${RELEASE_TAG}/MinecraftClient-linux.zip --output MinecraftClient-linux.zip
+  curl -L https://github.com/MCCTeam/Minecraft-Console-Client/releases/download/${RELEASE_TAG}/MinecraftClient-${MCC_PLATFORM:=linux}.zip --output MinecraftClient-linux.zip
 
   # Unzip it
   unzip MinecraftClient-linux.zip


### PR DESCRIPTION
Currently the example Dockerfile only works with amd64 architecture machines. This PR retains that default behaviour, however provides the ability to specify the MCC_PLATFORM environment variable, which changes the URL that the MCC release zip is downloaded from and so can be used to change the architecture to the desired one.