### PR TITLE
[skip ci] Miscellaneous scripting QoL improvements and fixes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-    if: ${{ !contains(github.event.head_commit.message, 'skip')}}
+    if: ${{ !contains(github.event.head_commit.message, 'skip') || !contains(github.event.head_commit.message, 'skipci')}}
     steps:
       - name: dummy action
         run: "echo 'dummy action that checks if the build is to be skipped, if it is, this action does not run to break the entire build action'"        

--- a/MinecraftClient/CommandHandler/CmdResult.cs
+++ b/MinecraftClient/CommandHandler/CmdResult.cs
@@ -22,7 +22,7 @@ namespace MinecraftClient.CommandHandler
         public CmdResult()
         {
             this.status = Status.NotRun;
-            this.result = null;
+            this.result = "Command did not run, cannot determine the result of the command.";
         }
 
         public Status status;
@@ -35,7 +35,7 @@ namespace MinecraftClient.CommandHandler
             this.result = status switch
             {
 #pragma warning disable format // @formatter:off
-                Status.NotRun             =>  null,
+                Status.NotRun             =>  "Command did not run, cannot determine the result of the command.",
                 Status.FailChunkNotLoad   =>  null,
                 Status.FailNeedEntity     =>  Translations.extra_entity_required,
                 Status.FailNeedInventory  =>  Translations.extra_inventory_required,

--- a/MinecraftClient/Scripting/CSharpRunner.cs
+++ b/MinecraftClient/Scripting/CSharpRunner.cs
@@ -187,8 +187,7 @@ namespace MinecraftClient.Scripting
         public CSErrorType ExceptionType { get { return _type; } }
         public override string Message { get { return InnerException!.Message; } }
         public override string ToString() { return InnerException!.ToString(); }
-        public CSharpException(CSErrorType type, Exception inner)
-            : base(inner != null ? inner.Message : "", inner)
+        public CSharpException(CSErrorType type, Exception inner) : base(inner.Message, inner)
         {
             _type = type;
         }

--- a/MinecraftClient/Scripting/CSharpRunner.cs
+++ b/MinecraftClient/Scripting/CSharpRunner.cs
@@ -116,10 +116,15 @@ namespace MinecraftClient.Scripting
 
                         foreach (var failure in result.Failures)
                         {
-                            ConsoleIO.WriteLogLine($"[Script] Error in {scriptName}, line:col{failure.Location.GetMappedLineSpan()}: [{failure.Id}] {failure.GetMessage()}");
+                            // Get the line that contains the error:
+
+                            var loc = failure.Location.GetMappedLineSpan();
+                            var line = code.Split('\n')[loc.StartLinePosition.Line];
+                            
+                            ConsoleIO.WriteLogLine($"[Script] Error in {scriptName}, on line ({line}): [{failure.Id}] {failure.GetMessage()}");
                         }
 
-                        throw new CSharpException(CSErrorType.InvalidScript, new InvalidProgramException("Compilation failed due to error."));
+                        throw new CSharpException(CSErrorType.InvalidScript, new InvalidProgramException("Compilation failed due to error(s)."));
                     }
 
                     ConsoleIO.WriteLogLine("[Script] Compilation done with no errors.");

--- a/MinecraftClient/Scripting/CSharpRunner.cs
+++ b/MinecraftClient/Scripting/CSharpRunner.cs
@@ -121,7 +121,7 @@ namespace MinecraftClient.Scripting
                             var loc = failure.Location.GetMappedLineSpan();
                             var line = code.Split('\n')[loc.StartLinePosition.Line];
                             
-                            ConsoleIO.WriteLogLine($"[Script] Error in {scriptName}, on line ({line}): [{failure.Id}] {failure.GetMessage()}");
+                            ConsoleIO.WriteLogLine($"[Script] Error in {scriptName}, on line ({line.Trim()}): [{failure.Id}] {failure.GetMessage()}");
                         }
 
                         throw new CSharpException(CSErrorType.InvalidScript, new InvalidProgramException("Compilation failed due to error(s)."));


### PR DESCRIPTION
- Changes the scripting error message from line numbers to presenting the actual line itself
- Attempts to fix "NotRun" errors by modifying the CSharpException to expose the inner exception message. (the NotRun value is only used in code paths that use CSharpException, so it is modified here.)