### PR TITLE
Hotfix for 'minecraft:chat_type' not present in the dictionary

### DIFF
--- a/MinecraftClient/Protocol/Message/ChatParser.cs
+++ b/MinecraftClient/Protocol/Message/ChatParser.cs
@@ -34,11 +34,18 @@ namespace MinecraftClient.Protocol.Message
         public static void ReadChatType(Dictionary<string, object> registryCodec)
         {
             Dictionary<int, MessageType> chatTypeDictionary = ChatId2Type ?? new();
-            var cpy = new Dictionary<string, object>(registryCodec);
             
+            // Check if the chat type registry is in the correct format
             if (!registryCodec.ContainsKey("minecraft:chat_type")) {
+                
+                // If not, then we force the registry to be in the correct format
                 if (registryCodec.ContainsKey("chat_type")) {
+                    
                     foreach (var key in registryCodec.Keys.ToArray()) {
+                        // Skip entries with a namespace already
+                        if (key.Contains(':', StringComparison.OrdinalIgnoreCase)) continue;
+
+                        // Assume all other entries are in the minecraft namespace
                         registryCodec["minecraft:" + key] = registryCodec[key];
                         registryCodec.Remove(key);
                     }

--- a/MinecraftClient/Protocol/Message/ChatParser.cs
+++ b/MinecraftClient/Protocol/Message/ChatParser.cs
@@ -34,8 +34,18 @@ namespace MinecraftClient.Protocol.Message
         public static void ReadChatType(Dictionary<string, object> registryCodec)
         {
             Dictionary<int, MessageType> chatTypeDictionary = ChatId2Type ?? new();
-            var chatTypeListNbt =
-                (object[])(((Dictionary<string, object>)registryCodec["minecraft:chat_type"])["value"]);
+            var cpy = new Dictionary<string, object>(registryCodec);
+            
+            if (!registryCodec.ContainsKey("minecraft:chat_type")) {
+                if (registryCodec.ContainsKey("chat_type")) {
+                    foreach (var key in registryCodec.Keys.ToArray()) {
+                        registryCodec["minecraft:" + key] = registryCodec[key];
+                        registryCodec.Remove(key);
+                    }
+                }
+            }
+            
+            var chatTypeListNbt = (object[])(((Dictionary<string, object>)registryCodec["minecraft:chat_type"])["value"]);
             foreach (var (chatName, chatId) in from Dictionary<string, object> chatTypeNbt in chatTypeListNbt
                      let chatName = (string)chatTypeNbt["name"]
                      let chatId = (int)chatTypeNbt["id"]


### PR DESCRIPTION
Fix for the `System.Collections.Generic.KeyNotFoundException: The given key 'minecraft:chat_type' was not present in the dictionary.` issue that has been plaguing us for weeks on end.

Not really sure if this fix is correct, but it works on my machine ¯\\\_(ツ)\_/¯