### PR TITLE
Fixed bug in `SetDimension` method of `World` class, where it would c…

### DIFF
--- a/MinecraftClient/Mapping/World.cs
+++ b/MinecraftClient/Mapping/World.cs
@@ -19,7 +19,7 @@ namespace MinecraftClient.Mapping
         /// <summary>
         /// The dimension info of the world
         /// </summary>
-        private static Dimension curDimension = new();
+        private static Dimension curDimension= new();
 
         private static readonly Dictionary<string, Dimension> dimensionList = new();
 
@@ -87,10 +87,32 @@ namespace MinecraftClient.Mapping
         /// </summary>
         /// <param name="name">	The name of the dimension type</param>
         /// <param name="nbt">The dimension type (NBT Tag Compound)</param>
-        public static void SetDimension(string name)
-        {
-            curDimension = dimensionList[name]; // Should not fail
-        }
+	public static void SetDimension(string name)
+	{
+	    // Try to get the dimension using the name as is
+	    if (dimensionList.TryGetValue(name, out Dimension dimension))
+	    {
+		curDimension = dimension;
+		return; // Dimension found
+	    }
+
+	    // If not found, check if name lacks 'minecraft:' prefix and try again
+	    if (!name.StartsWith("minecraft:"))
+	    {
+		string prefixedName = "minecraft:" + name;
+		if (dimensionList.TryGetValue(prefixedName, out dimension))
+		{
+		    curDimension = dimension;
+		    return; // Dimension found with prefixed name
+		}
+	    }
+
+	    // If still not found, dimension does not exist
+	    throw new KeyNotFoundException($"Dimension '{name}' not found in dimensions dictionary.");
+	}
+
+
+
 
 
         /// <summary>

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -660,7 +660,8 @@ namespace MinecraftClient.Protocol.Handlers
                                     {
                                         case >= MC_1_16_2_Version and <= MC_1_18_2_Version:
                                             World.StoreOneDimension(dimensionName, dimensionType!);
-                                            World.SetDimension(dimensionName);
+                                            // World.SetDimension(dimensionName);
+					    World.SetDimension(dimensionName);
                                             break;
                                         default:
                                             World.SetDimension(dimensionTypeName!);


### PR DESCRIPTION
Fixed bug in `SetDimension` method of `World` class, where it would crash if joining a paper server. Added error handling as well. 
The previous behavior remains unchanged, but instead of crashing, I added the possibility to have the dimension starting with "minecraft:". And after all that if still fails it throws an error. 