### PR TITLE
Update ChatLog.cs Improve filter options

### DIFF
--- a/MinecraftClient/ChatBots/ChatLog.cs
+++ b/MinecraftClient/ChatBots/ChatLog.cs
@@ -73,21 +73,25 @@ namespace MinecraftClient.ChatBots
                     saveOther = true;
                     savePrivate = true;
                     saveChat = true;
+                    saveInternal = true;
                     break;
                 case Configs.MessageFilter.messages:
                     saveOther = false;
                     savePrivate = true;
                     saveChat = true;
+                    saveInternal = true;
                     break;
                 case Configs.MessageFilter.chat:
                     saveOther = false;
                     savePrivate = false;
                     saveChat = true;
+                    saveInternal = false;
                     break;
                 case Configs.MessageFilter.private_chat:
                     saveOther = false;
                     savePrivate = true;
                     saveChat = false;
+                    saveInternal = false;
                     break;
                 case Configs.MessageFilter.internal_msg:
                     saveOther = false;


### PR DESCRIPTION
Modify the log filtering under the all, chat, private_chat, and messages branches so that in chat mode, only chat is recorded.
In the previous settings, even if you chose to only record chats, there would still be a lot of internal info in the chat log.