### PR TITLE
将删除Cookie的时间改成断开连接的时候。

### DIFF
--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -210,6 +210,7 @@ namespace MinecraftClient
         public void GetCookie(string key, out byte[]? data) => Cookies.TryGetValue(key, out data);
         public void SetCookie(string key, byte[] data) => Cookies[key] = data;
         public void DeleteCookie(string key) => Cookies.Remove(key, out var data);
+        public void DeleteAllCookies() => Cookies?.Clear();
         public (Location location, string material, string typeLabel, string[] frontText, string[] backText, bool isWaxed)[] GetKnownSigns()
         {
             lock (signDataLock)

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -4101,6 +4101,7 @@ namespace MinecraftClient.Protocol.Handlers
                 finally
                 {
                     socketWrapper.Disconnect();
+                    McClient.Instance?.DeleteAllCookies();
                 }
             }
         }
@@ -6685,8 +6686,6 @@ namespace MinecraftClient.Protocol.Handlers
                         SendPacket(PacketTypesOut.CookieResponse, packet);
                         break;
                 }
-
-                McClient.Instance?.DeleteCookie(name);
                 return true;
             }
             catch (SocketException)


### PR DESCRIPTION
原有的SendCookieResponse逻辑是在请求后马上删除，但是某些服务器会在验证和登录阶段多次请求同一个Cookie，导致玩家被服务器踢出。
我在McClient中添加了删除所有Cookie的方法，并在Protocol18的Dispose里引用了它。另外，我删除了SendCookieResponse中的删除Cookie操作。