### PR TITLE
Implement error handling for RecipeBookAdd packet

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -3504,7 +3504,16 @@ namespace MinecraftClient.Protocol.Handlers
 
                 case PacketTypesIn.RecipeBookAdd:
                     if (protocolVersion >= MC_1_21_2_Version)
-                        HandleRecipeBookAdd(packetData);
+                    {
+                        try
+                        {
+                            HandleRecipeBookAdd(packetData);
+                        }
+                        catch
+                        {
+                            // Ignore this packet due to oversized VarInt from anti-MCC server
+                        }
+                    }
                     break;
                 case PacketTypesIn.RecipeBookRemove:
                     if (protocolVersion >= MC_1_21_2_Version)


### PR DESCRIPTION
Added error handling for RecipeBookAdd packet to ignore oversized VarInt.
This is just a temporary measure. It prevents MCC from crashing when encountering oversized (or non-standard) recipe packages.